### PR TITLE
[WIP] Update Windows compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,12 +39,13 @@ install:
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
     - cd c:\projects\box
+    - echo @php %%~dp0composer.phar %%* > composer.bat
     - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
     - php composer.phar self-update
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
-    - IF %dependencies%==lowest appveyor-retry php composer.phar update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==current appveyor-retry php composer.phar update --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==highest appveyor-retry php composer.phar update --no-progress -n --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==lowest appveyor-retry composer update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==current appveyor-retry composer update --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==highest appveyor-retry composer update --no-progress -n --ansi --no-suggest --prefer-dist -n
 
 test_script:
     - cd c:\projects\box

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,4 +47,4 @@ install:
 
 test_script:
     - cd c:\projects\box
-    - php bin/phpunit
+    - bin/phpunit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ environment:
 
 cache:
     - '%LOCALAPPDATA%\Composer\files'
+    - composer.phar
     - C:\ProgramData\chocolatey\bin -> .appveyor.yml
     - C:\ProgramData\chocolatey\lib -> .appveyor.yml
     - c:\tools\php -> .appveyor.yml
@@ -37,9 +38,12 @@ install:
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
     - cd c:\projects\box
-    - IF %dependencies%==lowest appveyor-retry php bin/composer update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==current appveyor-retry php bin/composer install --no-progress --ansi -n
-    - IF %dependencies%==highest appveyor-retry php bin/composer update --no-progress -n --ansi --no-suggest --prefer-dist -n
+    - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
+    - php composer.phar self-update
+    - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
+    - IF %dependencies%==lowest appveyor-retry php composer.phar update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==current appveyor-retry php composer.phar update --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==highest appveyor-retry php composer.phar update --no-progress -n --ansi --no-suggest --prefer-dist -n
 
 test_script:
     - cd c:\projects\box

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,6 @@ environment:
 
 cache:
     - '%LOCALAPPDATA%\Composer\files'
-    - composer.phar
     - C:\ProgramData\chocolatey\bin -> .appveyor.yml
     - C:\ProgramData\chocolatey\lib -> .appveyor.yml
     - c:\tools\php -> .appveyor.yml
@@ -38,12 +37,9 @@ install:
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
     - cd c:\projects\box
-    - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
-    - php composer.phar self-update
-    - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
-    - IF %dependencies%==lowest appveyor-retry php composer.phar update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==current appveyor-retry php composer.phar update --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==highest appveyor-retry php composer.phar update --no-progress -n --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==lowest appveyor-retry php bin/composer update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==current appveyor-retry php bin/composer install --no-progress --ansi -n
+    - IF %dependencies%==highest appveyor-retry php bin/composer update --no-progress -n --ansi --no-suggest --prefer-dist -n
 
 test_script:
     - cd c:\projects\box

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,13 +38,12 @@ install:
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
     - cd c:\projects\box
-    - echo @php %%~dp0composer.phar %%* > composer.bat
     - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
     - php composer.phar self-update
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
-    - IF %dependencies%==lowest appveyor-retry composer update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==current appveyor-retry composer update --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==highest appveyor-retry composer update --no-progress -n --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==lowest appveyor-retry php composer.phar update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==current appveyor-retry php composer.phar update --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==highest appveyor-retry php composer.phar update --no-progress -n --ansi --no-suggest --prefer-dist -n
 
 test_script:
     - cd c:\projects\box

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,6 @@ cache:
 init:
     - SET PATH=C:\Program Files\OpenSSL;c:\tools\php\%PHP_VERSION%;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
-    - SET ANSICON=121x90 (121x90)
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,4 +43,4 @@ install:
 
 test_script:
     - cd c:\projects\box
-    - bin/phpunit
+    - make test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,12 +6,8 @@ version: '{build}.{branch}'
 
 environment:
   matrix:
-  - dependencies: lowest
-    php_ver_target: 7.1
-  - dependencies: current
-    php_ver_target: 7.2
-  - dependencies: highest
-    php_ver_target: 7.3
+  - php_ver_target: 7.1
+  - php_ver_target: 7.2
 
 cache:
     - '%LOCALAPPDATA%\Composer\files'
@@ -41,9 +37,7 @@ install:
     - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
     - php composer.phar self-update
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
-    - IF %dependencies%==lowest appveyor-retry php composer.phar update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==current appveyor-retry php composer.phar update --no-progress --ansi --no-suggest --prefer-dist -n
-    - IF %dependencies%==highest appveyor-retry php composer.phar update --no-progress -n --ansi --no-suggest --prefer-dist -n
+    - appveyor-retry php composer.phar install --no-interaction --no-progress --no-suggest --prefer-dist
 
 test_script:
     - cd c:\projects\box

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,6 @@ install:
     - IF NOT EXIST c:\php mkdir c:\php
     - IF NOT EXIST c:\php\%php_ver_target% mkdir c:\php\%php_ver_target%
     - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php\%php_ver_target%""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-    - choco install make
     - cd c:\tools\php\%php_ver_target%
     - copy php.ini-production php.ini /Y
     - echo date.timezone="UTC" >> php.ini
@@ -49,4 +48,4 @@ install:
 
 test_script:
     - cd c:\projects\box
-    - make test
+    - bin\phpunit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,7 @@ install:
     - echo extension=php_openssl.dll >> php.ini
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
+    - echo extension=php_bz2.dll >> php.ini
     - cd c:\projects\box
     - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
     - php composer.phar self-update

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,7 @@ install:
     - IF NOT EXIST c:\php mkdir c:\php
     - IF NOT EXIST c:\php\%php_ver_target% mkdir c:\php\%php_ver_target%
     - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php\%php_ver_target%""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - choco install make
     - cd c:\tools\php\%php_ver_target%
     - copy php.ini-production php.ini /Y
     - echo date.timezone="UTC" >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,8 @@ version: '{build}.{branch}'
 
 environment:
   matrix:
-  - php_ver_target: 7.1
-  - php_ver_target: 7.2
+  - PHP_VERSION: 7.1
+  - PHP_VERSION: 7.2
 
 cache:
     - '%LOCALAPPDATA%\Composer\files'
@@ -17,16 +17,16 @@ cache:
     - c:\tools\php -> .appveyor.yml
 
 init:
-    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php\%php_ver_target%;%PATH%
+    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php\%PHP_VERSION%;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET ANSICON=121x90 (121x90)
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
 
 install:
     - IF NOT EXIST c:\php mkdir c:\php
-    - IF NOT EXIST c:\php\%php_ver_target% mkdir c:\php\%php_ver_target%
-    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php\%php_ver_target%""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-    - cd c:\tools\php\%php_ver_target%
+    - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php\%PHP_VERSION%""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:PHP_VERSION | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - cd c:\tools\php\%PHP_VERSION%
     - copy php.ini-production php.ini /Y
     - echo date.timezone="UTC" >> php.ini
     - echo extension_dir=ext >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,51 @@
+build: false
+platform:
+  - x64
+clone_folder: c:\projects\box
+version: '{build}.{branch}'
+
+environment:
+  matrix:
+  - dependencies: lowest
+    php_ver_target: 7.1
+  - dependencies: current
+    php_ver_target: 7.2
+  - dependencies: highest
+    php_ver_target: 7.3
+
+cache:
+    - '%LOCALAPPDATA%\Composer\files'
+    - composer.phar
+    - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+    - C:\ProgramData\chocolatey\lib -> .appveyor.yml
+    - c:\tools\php -> .appveyor.yml
+
+init:
+    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php\%php_ver_target%;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET ANSICON=121x90 (121x90)
+    - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
+
+install:
+    - IF NOT EXIST c:\php mkdir c:\php
+    - IF NOT EXIST c:\php\%php_ver_target% mkdir c:\php\%php_ver_target%
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php\%php_ver_target%""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - cd c:\tools\php\%php_ver_target%
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - cd c:\projects\box
+    - echo @php %%~dp0composer.phar %%* > composer.bat
+    - IF NOT EXIST composer.phar (appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
+    - php composer.phar self-update
+    - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
+    - IF %dependencies%==lowest appveyor-retry composer update --prefer-lowest --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==current appveyor-retry composer update --no-progress --ansi --no-suggest --prefer-dist -n
+    - IF %dependencies%==highest appveyor-retry composer update --no-progress -n --ansi --no-suggest --prefer-dist -n
+
+test_script:
+    - cd c:\projects\box
+    - php bin/phpunit

--- a/src/Test/FileSystemTestCase.php
+++ b/src/Test/FileSystemTestCase.php
@@ -35,6 +35,11 @@ abstract class FileSystemTestCase extends TestCase
     protected $tmp;
 
     /**
+     * @var string
+     */
+    protected $ds = DIRECTORY_SEPARATOR;
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp(): void
@@ -75,7 +80,7 @@ abstract class FileSystemTestCase extends TestCase
         $files = array_values(
             array_map(
                 function (string $file) use ($root): string {
-                    return str_replace($root.DIRECTORY_SEPARATOR, '', $file);
+                    return str_replace([$root.DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR], ['', '/'], $file);
                 },
                 $files
             )

--- a/tests/Composer/ComposerConfigurationTest.php
+++ b/tests/Composer/ComposerConfigurationTest.php
@@ -217,8 +217,6 @@ class ComposerConfigurationTest extends FileSystemTestCase
 }
 JSON;
 
-    private $ds = DIRECTORY_SEPARATOR;
-
     public function test_it_returns_an_empty_list_when_trying_to_retrieve_the_list_of_dev_packages_when_no_composer_json_file_is_found(): void
     {
         $this->assertSame([], ComposerConfiguration::retrieveDevPackages($this->tmp, null, null));

--- a/tests/Composer/ComposerConfigurationTest.php
+++ b/tests/Composer/ComposerConfigurationTest.php
@@ -217,6 +217,8 @@ class ComposerConfigurationTest extends FileSystemTestCase
 }
 JSON;
 
+    private $ds = DIRECTORY_SEPARATOR;
+
     public function test_it_returns_an_empty_list_when_trying_to_retrieve_the_list_of_dev_packages_when_no_composer_json_file_is_found(): void
     {
         $this->assertSame([], ComposerConfiguration::retrieveDevPackages($this->tmp, null, null));
@@ -228,12 +230,12 @@ JSON;
         $decodedComposerJson = [];
         $decodedComposerLock = json_decode(self::COMPOSER_LOCK_SAMPLE, true);
 
-        mkdir('vendor/bamarni/composer-bin-plugin');
-        mkdir('vendor/doctrine/instantiator');
+        mkdir("vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin");
+        mkdir("vendor{$this->ds}doctrine{$this->ds}instantiator");
 
         $expected = [
-            $this->tmp.'/vendor/bamarni/composer-bin-plugin',
-            $this->tmp.'/vendor/doctrine/instantiator',
+            $this->tmp."{$this->ds}vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin",
+            $this->tmp."{$this->ds}vendor{$this->ds}doctrine{$this->ds}instantiator",
         ];
 
         $actual = ComposerConfiguration::retrieveDevPackages($this->tmp, $decodedComposerJson, $decodedComposerLock);
@@ -246,12 +248,12 @@ JSON;
         $decodedComposerJson = ['config' => []];
         $decodedComposerLock = json_decode(self::COMPOSER_LOCK_SAMPLE, true);
 
-        mkdir('vendor/bamarni/composer-bin-plugin');
-        mkdir('vendor/doctrine/instantiator');
+        mkdir("vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin");
+        mkdir("vendor{$this->ds}doctrine{$this->ds}instantiator");
 
         $expected = [
-            $this->tmp.'/vendor/bamarni/composer-bin-plugin',
-            $this->tmp.'/vendor/doctrine/instantiator',
+            $this->tmp."{$this->ds}vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin",
+            $this->tmp."{$this->ds}vendor{$this->ds}doctrine{$this->ds}instantiator",
         ];
 
         $actual = ComposerConfiguration::retrieveDevPackages($this->tmp, $decodedComposerJson, $decodedComposerLock);
@@ -264,11 +266,11 @@ JSON;
         $decodedComposerJson = [];
         $decodedComposerLock = json_decode(self::COMPOSER_LOCK_SAMPLE, true);
 
-        mkdir('vendor/bamarni/composer-bin-plugin');
+        mkdir("vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin");
         // Doctrine Instantiator vendor does not exists
 
         $expected = [
-            $this->tmp.'/vendor/bamarni/composer-bin-plugin',
+            $this->tmp."{$this->ds}vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin",
         ];
 
         $actual = ComposerConfiguration::retrieveDevPackages($this->tmp, $decodedComposerJson, $decodedComposerLock);
@@ -285,11 +287,11 @@ JSON;
         ];
         $decodedComposerLock = json_decode(self::COMPOSER_LOCK_SAMPLE, true);
 
-        mkdir('custom-vendor/bamarni/composer-bin-plugin');
-        mkdir('vendor/doctrine/instantiator');  // Wrong directory
+        mkdir("custom-vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin");
+        mkdir("vendor{$this->ds}doctrine{$this->ds}instantiator");  // Wrong directory
 
         $expected = [
-            $this->tmp.'/custom-vendor/bamarni/composer-bin-plugin',
+            $this->tmp."{$this->ds}custom-vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin",
         ];
 
         $actual = ComposerConfiguration::retrieveDevPackages($this->tmp, $decodedComposerJson, $decodedComposerLock);
@@ -404,8 +406,8 @@ JSON
             true
         );
 
-        mkdir('custom-vendor/bamarni/composer-bin-plugin');
-        mkdir('vendor/doctrine/instantiator');  // Wrong directory
+        mkdir("custom-vendor{$this->ds}bamarni{$this->ds}composer-bin-plugin");
+        mkdir("vendor{$this->ds}doctrine{$this->ds}instantiator");  // Wrong directory
 
         $expected = [];
 

--- a/tests/ConfigurationFileTest.php
+++ b/tests/ConfigurationFileTest.php
@@ -1126,7 +1126,7 @@ JSON
     {
         $this->setConfig([
             'blacklist' => [
-                '/nowhere',
+                ($this->isWindows() ? 'C:' : '') . '/nowhere',
             ],
         ]);
 

--- a/tests/RequirementChecker/RequirementsDumperTest.php
+++ b/tests/RequirementChecker/RequirementsDumperTest.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\RequirementChecker;
 
+use KevinGH\Box\Test\FileSystemTestCase;
 use Phar;
-use PHPUnit\Framework\TestCase;
 use function array_column;
 
 /**
  * @covers \KevinGH\Box\RequirementChecker\RequirementsDumper
  */
-class RequirementsDumperTest extends TestCase
+class RequirementsDumperTest extends FileSystemTestCase
 {
     /**
      * @dataProvider provideJsonAndLockContents
@@ -75,7 +75,7 @@ class RequirementsDumperTest extends TestCase
 
         $this->assertSame(
             $expectedFiles,
-            array_column($checkFiles, 0)
+            $this->normalizePaths(array_column($checkFiles, 0))
         );
 
         $this->assertSame($expectedRequirement, $checkFiles[0][1]);


### PR DESCRIPTION
Fixes #193

This PR adds a [Appveyor](https://www.appveyor.com/) configuration to run CI on Windows machines, and also tries to address some windows compatibility.

There are currrently a lot of failures related to path names (See an example of some of the build failures: https://ci.appveyor.com/project/pierredup/box/build/job/yv2tts08s4ilxft4)) which needs to be updated first to get as much tests as possible to pass, so that the actual Windows issues can be clearly identified.

Appveyor will need to be enabled for this repository, so that all future builds can run against windows to ensure compatibility doesn't break.