### PR TITLE
Allows to use a callback as metadata producer

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -762,6 +762,30 @@ This setting will be ignored if no [key][key] has been provided.
 The metadata (`any` default none) setting can be any value. This value will be stored as metadata that can be retrieved
 from the built PHAR ([`Phar::getMetadata()][phar.getmetadata]).
 
+If you specify a closure as string setting, if will be evaluate without any arguments.
+
+For example, if you take the following code:
+
+```php
+<?php
+class MyCallbacks
+{
+    public static function generateMetadata()
+    {
+        return ['application_version' => '1.0.0-dev'];
+    }
+}
+```
+
+With the configuration excerpt:
+
+```json
+{
+    "metadata": "MyCallbacks\\generateMetadata"
+}
+```
+
+Then the `Phar::getMetadata()` will return `['application_version' => '1.0.0-dev']` array.
 
 ## Replaceable placeholders
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -787,6 +787,7 @@ With the configuration excerpt:
 
 Then the `Phar::getMetadata()` will return `['application_version' => '1.0.0-dev']` array.
 
+
 ## Replaceable placeholders
 
 This feature allows you to set placeholders in your code which will be replaced by different values by Box when building

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -762,7 +762,7 @@ This setting will be ignored if no [key][key] has been provided.
 The metadata (`any` default none) setting can be any value. This value will be stored as metadata that can be retrieved
 from the built PHAR ([`Phar::getMetadata()][phar.getmetadata]).
 
-If you specify a closure as string setting, if will be evaluate without any arguments.
+If you specify a callable (as a string), if will be evaluate without any arguments.
 
 For example, if you take the following code:
 

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -544,6 +544,10 @@ HELP;
                 'Setting metadata'
             );
 
+            if (is_callable($metadata)) {
+                $metadata = $metadata();
+            }
+
             $logger->log(
                 CompilerLogger::MINUS_PREFIX,
                 is_string($metadata) ? $metadata : var_export($metadata, true)

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -27,6 +27,7 @@ use function filesize;
 use function get_class;
 use Humbug\PhpScoper\Whitelist;
 use function implode;
+use function is_callable;
 use function is_string;
 use KevinGH\Box\Box;
 use const KevinGH\Box\BOX_ALLOW_XDEBUG;


### PR DESCRIPTION
In my projects I wanted a process that will build automatically (via composer) a fresh phar version as soon as my vendors changed.
And add also the corresponding manifest as metadata in phar file without to edit the `box.json.dist` file that accept only a hardcoded value.

This PR allow to use a custom callback.

See https://github.com/llaville/php-compatinfo-db/issues/59 my implementation with the custom callback (as example) and how I did all the automated process via composer.
