### PR TITLE
Add curl example to install docs

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -10,6 +10,12 @@
 The preferred method of installation is to use the Box PHAR which can be downloaded from the most recent
 [Github Release][releases]. This method ensures you will not have any dependency conflict issue.
 
+From a script or command line, you can download the latest release using curl:
+
+```bash
+$ curl -f -L https://github.com/humbug/box/releases/latest/download/box.phar -o box.phar
+```
+
 
 ## Phive
 


### PR DESCRIPTION
Sometimes the phar is missing from Box releases (#530). Users should be sure to pass the `-f / --fail` flag to curl so that it returns a non-zero exit code when the release is missing (i.e. Github returns 404). An example is helpful here, since the need for this flag may not be obvious.