### PR TITLE
Fix FileSystem::remove with file on Windows

### DIFF
--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -541,7 +541,7 @@ final class FileSystem extends SymfonyFilesystem
         $files = array_reverse($files);
         foreach ($files as $file) {
             // MODIFIED CODE
-            if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            if (defined('PHP_WINDOWS_VERSION_BUILD') && is_dir($file)) {
                 exec(sprintf('rd /s /q %s', escapeshellarg($file)));
             // - MODIFIED CODE
             } elseif (is_link($file)) {


### PR DESCRIPTION
On Windows `FileSystem::remove` uses the native `rd` command (remove a directory) on all file system types, which obviously fails with something that is not a directory. Fixes #536 