### PR TITLE
Upgrade to xdebug-handler 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "amphp/parallel-functions": "^0.1.3",
         "composer/package-versions-deprecated": "^1.8",
         "composer/semver": "^3.2",
-        "composer/xdebug-handler": "^1.3.2",
+        "composer/xdebug-handler": "^2.0",
         "humbug/php-scoper": "^0.13.10 || ^0.14",
         "justinrainbow/json-schema": "^5.2.9",
         "nikic/iter": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c566d8c7b0f87d1504f3e6839e8b1f0a",
+    "content-hash": "22758b40a6cdc4ceea479ee76fda0736",
     "packages": [
         {
             "name": "amphp/amp",
@@ -675,16 +675,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "31d57697eb1971712a08031cfaff5a846d10bdf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/31d57697eb1971712a08031cfaff5a846d10bdf5",
+                "reference": "31d57697eb1971712a08031cfaff5a846d10bdf5",
                 "shasum": ""
             },
             "require": {
@@ -692,7 +692,8 @@
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "autoload": {
@@ -718,7 +719,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.0"
             },
             "funding": [
                 {
@@ -734,7 +735,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2021-04-09T19:40:06+00:00"
         },
         {
             "name": "humbug/php-scoper",

--- a/fixtures/php-settings-checker/output-pharreadonly-enabled
+++ b/fixtures/php-settings-checker/output-pharreadonly-enabled
@@ -4,7 +4,7 @@
 [debug] The xdebug extension is not loaded
 [debug] Configured `phar.readonly=0`
 [debug] Process restarting (BOX_ALLOW_XDEBUG=internal||1|*|*)
-[debug] Running '/usr/local/bin/php' './box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
+[debug] Running /usr/local/bin/php ./box compile --working-dir=fixtures/php-settings-checker -vvv --no-ansi
 [debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] Restarted (100 ms). The xdebug extension is not loaded

--- a/fixtures/php-settings-checker/output-xdebug-enabled.tpl
+++ b/fixtures/php-settings-checker/output-xdebug-enabled.tpl
@@ -1,9 +1,9 @@
 [debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is disabled
-[debug] The xdebug extension is loaded (__XDEBUG_VERSION__)
+[debug] The xdebug extension is loaded (__XDEBUG_VERSION__) mode=develop
 [debug] Process restarting (BOX_ALLOW_XDEBUG=internal|__XDEBUG_VERSION__|1|*|*)
-[debug] Running '/usr/local/bin/php' './box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
+[debug] Running /usr/local/bin/php ./box compile --working-dir=fixtures/php-settings-checker -vvv --no-ansi
 [debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] Restarted (100 ms). The xdebug extension is not loaded

--- a/src/Console/Php/PhpSettingsHandler.php
+++ b/src/Console/Php/PhpSettingsHandler.php
@@ -41,7 +41,7 @@ final class PhpSettingsHandler extends XdebugHandler
      */
     public function __construct(LoggerInterface $logger)
     {
-        parent::__construct('box', '--ansi');
+        parent::__construct('box');
 
         $this->setPersistent();
 
@@ -54,17 +54,17 @@ final class PhpSettingsHandler extends XdebugHandler
     /**
      * {@inheritdoc}
      */
-    public function check()
+    public function check(): void
     {
         $this->bumpMemoryLimit();
 
-        return parent::check();
+        parent::check();
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function requiresRestart($isLoaded): bool
+    protected function requiresRestart($default): bool
     {
         if ($this->pharReadonly) {
             $this->logger->debug('phar.readonly is enabled');
@@ -74,7 +74,7 @@ final class PhpSettingsHandler extends XdebugHandler
 
         $this->logger->debug('phar.readonly is disabled');
 
-        return parent::requiresRestart($isLoaded);
+        return parent::requiresRestart($default);
     }
 
     /**


### PR DESCRIPTION
This adds support for Xdebug3 modes and changes the default behaviour from always restarting if Xdebug is loaded, to only restarting if Xdebug is active. 

Xdebug is considered active if it is loaded, and for Xdebug3, if it is running in a mode other than `xdebug.mode=off`.