### PR TITLE
PHP 8.1: fix two deprecation warnings

### DIFF
--- a/requirement-checker/src/RequirementCollection.php
+++ b/requirement-checker/src/RequirementCollection.php
@@ -15,6 +15,7 @@ namespace KevinGH\RequirementChecker;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -36,6 +37,7 @@ final class RequirementCollection implements IteratorAggregate, Countable
      *
      * @return Requirement[]|Traversable
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->requirements);
@@ -44,6 +46,7 @@ final class RequirementCollection implements IteratorAggregate, Countable
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return \count($this->requirements);


### PR DESCRIPTION
A run on PHP 8.1 currently shows:
```
Deprecated: Return type of HumbugBox3100\KevinGH\RequirementChecker\RequirementCollection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in path/to/.box/src/RequirementCollection.php on line 12
[php-scoper]
[php-scoper] Deprecated: Return type of HumbugBox3100\KevinGH\RequirementChecker\RequirementCollection::count() should either be compatible with Countable::count(): int, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in path/to/.box/src/RequirementCollection.php on line 16
```

These deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

~~As this package has a minimum PHP requirement of PHP 7.3 based on the `composer.json` file, these return types can be safely added.~~

**_As this package still has a minimum PHP requirement of PHP 5.3 based on the `composer.json` file, the return type (PHP 7.0 feature) can not be added, so I've added the attribute instead._**

**_While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added._**