### PR TITLE
GH Actions: turn on testing against PHP 8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,19 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ 7.3, 7.4, 8.0 ]
+                php: [ '7.3', '7.4', '8.0' ]
                 tools: [ "composer:v1", "composer:v2" ]
                 phar-readonly: [ true, false ]
+
+                include:
+                    - php: '8.1'
+                      tools: 'composer:v2'
+                      phar-readonly: true
+                    - php: '8.1'
+                      tools: 'composer:v2'
+                      phar-readonly: false
+
+        continue-on-error: ${{ matrix.php == '8.1' }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -47,10 +57,20 @@ jobs:
                         composer-
 
             -   name: Install dependencies
+                if: ${{ matrix.php < 8.1 }}
                 run: composer install --no-interaction --no-progress --prefer-dist
 
             -   name: Install requirement-checker dependencies
+                if: ${{ matrix.php < 8.1 }}
                 run: composer install --no-interaction --no-progress --prefer-dist --working-dir requirement-checker
+
+            -   name: Install dependencies (PHP 8.1, ignore platform reqs)
+                if: ${{ matrix.php >= 8.1 }}
+                run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
+
+            -   name: Install requirement-checker dependencies (PHP 8.1, ignore platform reqs)
+                if: ${{ matrix.php >= 8.1 }}
+                run: composer install --no-interaction --no-progress --prefer-dist --working-dir requirement-checker --ignore-platform-reqs
 
             -   name: validate box config
                 run: bin/box validate
@@ -120,6 +140,28 @@ jobs:
                 php: [ '7.3', '8.0' ]
                 tools: [ 'composer:v1', 'composer:v2' ]
 
+                include:
+                    - e2e: 'e2e_php_settings_checker'
+                      php: '8.1'
+                      tools: 'composer:v2'
+                    - e2e: 'e2e_scoper_alias'
+                      php: '8.1'
+                      tools: 'composer:v2'
+                    - e2e: 'e2e_scoper_whitelist'
+                      php: '8.1'
+                      tools: 'composer:v2'
+                    - e2e: 'e2e_check_requirements'
+                      php: '8.1'
+                      tools: 'composer:v2'
+                    - e2e: 'e2e_symfony'
+                      php: '8.1'
+                      tools: 'composer:v2'
+                    - e2e: 'e2e_composer_installed_versions'
+                      php: '8.1'
+                      tools: 'composer:v2'
+
+        continue-on-error: ${{ matrix.php == '8.1' }}
+
         steps:
             -   uses: actions/checkout@v2
                 with:
@@ -148,10 +190,20 @@ jobs:
                         composer-
 
             -   name: Install dependencies
+                if: ${{ matrix.php < 8.1 }}
                 run: composer install --no-interaction --no-progress --no-suggest --prefer-dist
 
             -   name: Install requirement-checker dependencies
+                if: ${{ matrix.php < 8.1 }}
                 run: composer install --no-interaction --no-progress --prefer-dist --working-dir requirement-checker
+
+            -   name: Install dependencies (PHP 8.1, ignore platform reqs)
+                if: ${{ matrix.php >= 8.1 }}
+                run: composer install --no-interaction --no-progress --no-suggest --prefer-dist --ignore-platform-reqs
+
+            -   name: Install requirement-checker dependencies (PHP 8.1, ignore platform reqs)
+                if: ${{ matrix.php >= 8.1 }}
+                run: composer install --no-interaction --no-progress --prefer-dist --working-dir requirement-checker --ignore-platform-reqs
 
             -   name: Run e2e ${{ matrix.e2e }}
                 run: make ${{ matrix.e2e }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    ini-values: phar.readonly=0
+                    ini-values: phar.readonly=0, display_errors=On, error_reporting=-1
                     tools: ${{ matrix.tools }}
                     coverage: none
                     extensions: ctype, iconv, xml
@@ -96,7 +96,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: 7.4
-                    ini-values: phar.readonly=0
+                    ini-values: phar.readonly=0, display_errors=On, error_reporting=-1
                     tools: composer:v2
                     coverage: pcov
                     extensions: ctype, iconv, xml
@@ -171,7 +171,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    ini-values: "phar.readonly=0"
+                    ini-values: "phar.readonly=0, display_errors=On, error_reporting=-1"
                     tools: ${{ matrix.tools }}
                     coverage: pcov
 
@@ -221,7 +221,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: 7.3
-                    ini-values: phar.readonly=0
+                    ini-values: phar.readonly=0, display_errors=On, error_reporting=-1
                     tools: composer:v2
                     coverage: none
 


### PR DESCRIPTION
### GH Actions: turn on testing against PHP 8.1

This commit adds running of the tests against PHP 8.1 to the GH Actions script.

Notes:
* As Composer v1 is not compatible with PHP 8.1 and, I suspect, will not be made compatible with PHP 8.1, PHP 8.1 cannot be added to the matrix array, but individual builds for PHP 8.1 (using Composer v2) have to be defined via `matrix:include`.
* As the PHPUnit Prophecy dependency does not yet allow for installation on PHP 8.1, the `composer install` for PHP 8.1 has to be special cased to use `--ignore-platform-reqs` (for the time being).
* As there are multiple dependencies of Box which have not yet released a PHP 8.1 compatible version, the builds against PHP 8.1 are allowed to fail via `continue-on-error` for now.

About the dependency failures:
* A PR has been opened against `nikic/iter` to fix the PHP 8.1 incompatibility, see nikic/iter#88
* A PR is open against `symfony/symfony` to fix the PHP 8.1 incompatibility, see symfony/symfony#42260
    Other refs:
    - symfony/symfony#41552 (Meta issue)
    - symfony/symfony#42231 (Finder)
    - symfony/symfony#42199 (Console)

### GH Actions: set error reporting to -1

The default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with -1` and `display_errors=On` to ensure **all** PHP notices are shown.

