### PR TITLE
Fixed PHP 8.1 compatibility of the requirement checker

### DIFF
--- a/.requirement-checker/src/RequirementCollection.php
+++ b/.requirement-checker/src/RequirementCollection.php
@@ -9,10 +9,12 @@ use Traversable;
 final class RequirementCollection implements \IteratorAggregate, \Countable
 {
     private $requirements = array();
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->requirements);
     }
+    #[ReturnTypeWillChange]
     public function count()
     {
         return \count($this->requirements);

--- a/.requirement-checker/src/RequirementCollection.php
+++ b/.requirement-checker/src/RequirementCollection.php
@@ -5,7 +5,7 @@ namespace HumbugBox3100\KevinGH\RequirementChecker;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
-use Traversable;
+use ReturnTypeWillChange;
 final class RequirementCollection implements \IteratorAggregate, \Countable
 {
     private $requirements = array();


### PR DESCRIPTION
It looks like https://github.com/box-project/box/pull/557 wasn't enough to fix this. This file needs updating too.