### PR TITLE
PHP 8.1: properly fix the requirement checker

### DIFF
--- a/requirement-checker/src/RequirementCollection.php
+++ b/requirement-checker/src/RequirementCollection.php
@@ -15,7 +15,6 @@ namespace KevinGH\RequirementChecker;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
-use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -37,7 +36,7 @@ final class RequirementCollection implements IteratorAggregate, Countable
      *
      * @return Requirement[]|Traversable
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->requirements);
@@ -46,7 +45,7 @@ final class RequirementCollection implements IteratorAggregate, Countable
     /**
      * {@inheritdoc}
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->requirements);


### PR DESCRIPTION
When box packaging it prefixes attribute class with HumbugBox release version

This was broken after efdf63bb78598dac449407d4227c161520197535 see https://github.com/box-project/box/blob/efdf63bb78598dac449407d4227c161520197535/.requirement-checker/src/RequirementCollection.php#L8

PS: follow-up to #578