### PR TITLE
Improve AMP error handling.

### DIFF
--- a/src/Amp/FailureCollector.php
+++ b/src/Amp/FailureCollector.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Amp;
+
+use Amp\MultiReasonException;
+use function array_map;
+use function array_unique;
+use KevinGH\Box\NotInstantiable;
+use Throwable;
+
+final class FailureCollector
+{
+    use NotInstantiable;
+
+    /**
+     * @return list<string>
+     */
+    public static function collectReasons(MultiReasonException $exception): array
+    {
+        return array_unique(
+            array_map(
+                static fn (Throwable $throwable) => $throwable->getMessage(),
+                $exception->getReasons(),
+            ),
+        );
+    }
+}

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -28,6 +28,7 @@ use Humbug\PhpScoper\Symbol\SymbolsRegistry;
 use function implode;
 use function is_callable;
 use function is_string;
+use KevinGH\Box\Amp\FailureCollector;
 use KevinGH\Box\Box;
 use const KevinGH\Box\BOX_ALLOW_XDEBUG;
 use function KevinGH\Box\bump_open_file_descriptor_limit;
@@ -391,16 +392,7 @@ HELP;
 
         $count = count($config->getFiles());
 
-        try {
-            $box->addFiles($config->getFiles(), false);
-        } catch (MultiReasonException $exception) {
-            // This exception is handled a different way to give me meaningful feedback to the user
-            foreach ($exception->getReasons() as $reason) {
-                $io->error($reason);
-            }
-
-            throw $exception;
-        }
+        self::addFilesWithErrorHandling($config, $box, $io);
 
         $logger->log(
             CompilerLogger::CHEVRON_PREFIX,
@@ -408,6 +400,26 @@ HELP;
                 ? 'No file found'
                 : sprintf('%d file(s)', $count)
         );
+    }
+
+    private static function addFilesWithErrorHandling(Configuration $config, Box $box, IO $io): void
+    {
+        try {
+            $box->addFiles($config->getFiles(), false);
+
+            return;
+        } catch (MultiReasonException $ampFailure) {
+            // Continue
+        }
+
+        // This exception is handled a different way to give me meaningful feedback to the user
+        $io->error([
+            'An Amp\Parallel error occurred. To diagnostic if it is an Amp error related, you may try again with "--no-parallel".',
+            'Reason(s) of the failure:',
+            ...FailureCollector::collectReasons($ampFailure),
+        ]);
+
+        throw $ampFailure;
     }
 
     private function registerMainScript(Configuration $config, Box $box, CompilerLogger $logger): ?string


### PR DESCRIPTION
There was two issues before:

- We were giving `$io->error($throwableInstance)` which is really not clear how it should be handled and will likely result in a failure in the future
- Printing reach reasons.

The 2nd point is especially bad when the source of the failure is common. In this situation you will get as many reasons as workers fired up resulting a lot of identical reasons printed over and over.

In this PR:

- we pass the reason (string) to the IO
- we collect all the reasons beforehand to remove the duplicates
- add a message to help the user to diagnose the issue