### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
                 php: [ '8.1' ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
             -   name: Ensure the PHAR is scoped
                 run: bin/box.phar namespace | php -r 'if (!str_starts_with(stream_get_contents(STDIN), "_HumbugBox")) exit (1);'
 
-            -   uses: actions/upload-artifact@v2
+            -   uses: actions/upload-artifact@v3
                 name: Upload the PHAR artifact
                 with:
                     name: box-phar
@@ -60,7 +60,7 @@ jobs:
             - 'build-phar'
         if: github.event_name == 'release'
         steps:
-            -   uses: actions/download-artifact@v2
+            -   uses: actions/download-artifact@v3
                 with:
                     name: box-phar
                     path: .

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -29,7 +29,7 @@ jobs:
                 tools: [ 'composer:v2' ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
                 php: [ '8.1' ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
                 phar-readonly: [ true, false ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
                 tools: [ "composer:v2" ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/upload-artifact/releases