### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,10 @@ jobs:
                     coverage: none
 
             -   name: Install Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
 
             -   name: Install RequirementChecker Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 with:
                     working-directory: 'vendor-bin/requirement-checker'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
             -   name: Install RequirementChecker Composer dependencies
                 uses: ramsey/composer-install@v2
                 with:
-                    working-directory: 'vendor-bin/requirement-checker'
+                    working-directory: 'requirement-checker'
 
             -   name: Build PHAR
                 run: make compile

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -42,23 +42,23 @@ jobs:
                     coverage: pcov
 
             -   name: Install Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php) != true
 
             -   name: Install RequirementChecker Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php) != true
                 with:
                     working-directory: 'vendor-bin/requirement-checker'
 
             -   name: Install Composer dependencies (ignore PHP platform req)
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php)
                 with:
                     composer-options: --ignore-platform-req=php+
 
             -   name: Install RequirementChecker Composer dependencies (ignore PHP platform req)
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php)
                 with:
                     composer-options: --ignore-platform-req=php+

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,7 +49,7 @@ jobs:
                 uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php) != true
                 with:
-                    working-directory: 'vendor-bin/requirement-checker'
+                    working-directory: 'requirement-checker'
 
             -   name: Install Composer dependencies (ignore PHP platform req)
                 uses: ramsey/composer-install@v2
@@ -62,7 +62,7 @@ jobs:
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php)
                 with:
                     composer-options: --ignore-platform-req=php+
-                    working-directory: 'vendor-bin/requirement-checker'
+                    working-directory: 'requirement-checker'
 
             -   name: Ensure the Makefile does not run the Composer install command a 2nd time
                 run: touch -c composer.lock vendor requirement-checker/composer.lock requirement-checker/vendor

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -46,7 +46,7 @@ jobs:
                 uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php) != true
                 with:
-                    working-directory: 'vendor-bin/requirement-checker'
+                    working-directory: 'requirement-checker'
 
             -   name: Install Composer dependencies (ignore PHP platform req)
                 uses: ramsey/composer-install@v2
@@ -59,7 +59,7 @@ jobs:
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php)
                 with:
                     composer-options: --ignore-platform-req=php+
-                    working-directory: 'vendor-bin/requirement-checker'
+                    working-directory: 'requirement-checker'
 
             -   name: Ensure the Makefile does not run the Composer install command a 2nd time
                 run: touch -c composer.lock vendor requirement-checker/composer.lock requirement-checker/vendor
@@ -106,7 +106,7 @@ jobs:
             -   name: Install RequirementChecker Composer dependencies
                 uses: ramsey/composer-install@v2
                 with:
-                    working-directory: 'vendor-bin/requirement-checker'
+                    working-directory: 'requirement-checker'
 
             -   name: Run Infection
                 run: make tm

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -39,23 +39,23 @@ jobs:
                     extensions: ctype, iconv, xml
 
             -   name: Install Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php) != true
 
             -   name: Install RequirementChecker Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php) != true
                 with:
                     working-directory: 'vendor-bin/requirement-checker'
 
             -   name: Install Composer dependencies (ignore PHP platform req)
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php)
                 with:
                     composer-options: --ignore-platform-req=php+
 
             -   name: Install RequirementChecker Composer dependencies (ignore PHP platform req)
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 if: contains(env.FUTURE_PHP_VERSION, matrix.php)
                 with:
                     composer-options: --ignore-platform-req=php+
@@ -101,10 +101,10 @@ jobs:
                     extensions: ctype, iconv, xml
 
             -   name: Install Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
 
             -   name: Install RequirementChecker Composer dependencies
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v2
                 with:
                     working-directory: 'vendor-bin/requirement-checker'
 


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Note: v2 is a complete rewrite of the action.

Refs:
* https://github.com/ramsey/composer-install/releases/