### PR TITLE
Refactor Compile command

### DIFF
--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1815,8 +1815,8 @@ class CompileTest extends CommandTestCase
             'composer.json',
             // The following two files do not exists since there is no dependency, check BoxTest for a more complete
             // test regarding this feature
-            //'composer.lock',
-            //'vendor/composer/installed.json',
+            // 'composer.lock',
+            // 'vendor/composer/installed.json',
         ];
 
         foreach ($removedComposerFiles as $composerFile) {


### PR DESCRIPTION
Extracted from #646 

- Make methods static when possible
- Compare to the count rather than an empty array
- Avoid having an assignment in an if close
- Remove unnecessary dependency of `Command::getApplication()` e.g. when getting the logo
