### PR TITLE
Composer: minor tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.x-dev"
         },
         "bamarni-bin": {
             "bin-links": false

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef4873a396b2693352997e11f5cbe084",
+    "content-hash": "f91d5c9a5684761996f2f956601bcbd4",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
While updating a workflow to use Box 4.x, I noticed that the branch alias hadn't been updated.

Might also be worth it to mention in the changelog that the `sodium` extension is now a non-dev requirement for running Box (under BC-break).
The entry as-it-is under `Misc` was the reason for me to check the `composer.json` of the file to see what was required as an alternative, only to realize that the extension is now required.

[Edited]: the original PR also removed the `replace` command, but I now see why that was put in place.