### PR TITLE
Fix documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@
 /phpunit.xml
 /phpcs.xml
 /website/
+/site/

--- a/doc/assets/announce.css
+++ b/doc/assets/announce.css
@@ -2,20 +2,20 @@
     text-align: center;
 }
 
-.md-announce a,
-.md-announce a:focus {
+.md-banner a,
+.md-banner a:focus {
     color: white;
 }
 
-.md-announce a:hover {
+.md-banner a:hover {
     color: hotpink;
 }
 
-.md-announce strong {
+.md-banner strong {
     white-space: nowrap;
 }
 
-.md-announce .heart {
+.md-banner .heart {
     margin-left: 0.2em;
     color: deeppink;
 }

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -28,6 +28,7 @@ theme:
     icon:
         repo: fontawesome/brands/github
     palette:
+        scheme: default
         primary: brown
         accent: amber
     features:


### PR DESCRIPTION
Minor fixes on documentation site, according to new version of [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) theme.

-  In `mkdocs.yaml`, add `scheme: default` option, which now is mandatory.
- Adjust `doc/assets/announce.css` since the class applied to the announce bar now is `md-banner`, instead of `md-announce`