### PR TITLE
add docker image publishing after releasing box

### DIFF
--- a/.docker/php81_build_phar
+++ b/.docker/php81_build_phar
@@ -1,0 +1,19 @@
+FROM php:8.1-cli-alpine as build-stage
+
+RUN apk add --update make git
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+RUN mkdir -p /opt/box-project/box
+WORKDIR /opt/box-project/box
+ADD . /opt/box-project/box
+RUN cd /opt/box-project/box && \
+    make compile
+
+FROM php:8.1-cli-alpine
+
+COPY --from=build-stage /opt/box-project/box/bin/box.phar /usr/bin/box
+
+RUN mkdir -p /local
+WORKDIR /local
+ENTRYPOINT ["/usr/bin/box"]

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -25,6 +25,10 @@ jobs:
           target: 'releases/box.phar'
           token: ${{ secrets.GITHUB_TOKEN }}
       -
+        name: Make release executable
+        run:
+          chmod +x releases/box.phar
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,0 +1,46 @@
+name: Publish Docker image after release
+
+on:
+  workflow_run:
+    workflows:
+      - Build
+    types:
+      - completed
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Download Release
+        id: download_release
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          repo: 'box-project/box'
+          file: 'box.phar'
+          target: 'releases/box.phar'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          pull: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/box:${{ steps.download_release.outputs.version }},${{ secrets.DOCKERHUB_USERNAME }}/box:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.1-cli-alpine
+
+ADD releases/box.phar /usr/bin/box
+
+RUN mkdir -p /local
+WORKDIR /local
+ENTRYPOINT ["/usr/bin/box"]


### PR DESCRIPTION
fixes #693 by using a github action to create a docker image from the released artifact.

New secrets needed on the repo:
DOCKERHUB_USERNAME : username for dockerhub, also used as docker image repository name
DOCKERHUB_TOKEN : access token for docker, needs at least push privileges.
