### PR TITLE
Allow `$schema` in JSON schema

### DIFF
--- a/res/schema.json
+++ b/res/schema.json
@@ -4,6 +4,10 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "$schema": {
+            "description": "JSON schema location, e.g. ``vendor\/humbug\/box\/res\/schema.json``",
+            "type": [ "string", "null"]
+        },
         "algorithm": {
             "description": "The algorithm to use for signing the PHAR.",
             "type": ["string", "null"]

--- a/tests/DocumentationSchemaTest.php
+++ b/tests/DocumentationSchemaTest.php
@@ -55,7 +55,7 @@ class DocumentationSchemaTest extends TestCase
             ),
         );
 
-        $this->assertSame($schemaKeys, $docKeys);
+        $this->assertSame($schemaKeys, ['$schema', ...$docKeys]);
     }
 
     public function test_all_the_doc_keys_are_valid(): void
@@ -90,7 +90,7 @@ class DocumentationSchemaTest extends TestCase
             ),
         );
 
-        $this->assertEquals($schemaKeys, $docKeys);
+        $this->assertEquals($schemaKeys, '$schema', ...$docKeys]);
     }
 
     /**


### PR DESCRIPTION
Adding `{"$schema": "vendor/humbug/box/res/schema.json"}` to the config file allows PhpStorm to provide completions. However, the `$schema` key is reported as not allowed.