### PR TITLE
feat: rework docker generator to use mlocate and actually work

### DIFF
--- a/src/DockerFileGenerator.php
+++ b/src/DockerFileGenerator.php
@@ -95,14 +95,12 @@ final class DockerFileGenerator
         return strtr(
             self::FILE_TEMPLATE,
             [
-                //....
-            ],
-        );
             '__BASE_PHP_IMAGE_TOKEN__' => $this->image,
             '__PHAR_FILE_PATH_TOKEN__' => $this->sourcePhar,
             '__PHAR_FILE_NAME_TOKEN__' => basename($this->sourcePhar),
             '__REQUIRED_EXTENSIONS__' => implode(" ", $this->extensions)
-        ]);
+            ]
+        );
     }
 
     private static function retrievePhpImageName(array $requirements): string

--- a/src/DockerFileGenerator.php
+++ b/src/DockerFileGenerator.php
@@ -92,7 +92,12 @@ final class DockerFileGenerator
 
     public function generateStub(): string
     {
-        return strtr(self::FILE_TEMPLATE, [
+        return strtr(
+            self::FILE_TEMPLATE,
+            [
+                //....
+            ],
+        );
             '__BASE_PHP_IMAGE_TOKEN__' => $this->image,
             '__PHAR_FILE_PATH_TOKEN__' => $this->sourcePhar,
             '__PHAR_FILE_NAME_TOKEN__' => basename($this->sourcePhar),

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -1698,27 +1698,12 @@ class ConfigurationTest extends ConfigurationTestCase
 
     public function test_it_cannot_retrieve_the_git_hash_if_not_in_a_git_repository(): void
     {
-        try {
-            $this->setConfig([
-                'git' => 'git',
-            ]);
-
-            $this->fail('Expected exception to be thrown.');
-        } catch (RuntimeException $exception) {
-            $tmp = $this->tmp;
-
-            // Make the comparison case insensitive since depending of the git version the case may be different
-            $this->assertSame(
-                strtolower(
-                    sprintf(
-                        'The tag or commit hash could not be retrieved from "%s": fatal: Not a git repository '
-                        .'(or any of the parent directories): .git'.PHP_EOL,
-                        $tmp,
-                    ),
-                ),
-                strtolower($exception->getMessage()),
-            );
-        }
+        $regex = strtr('~^The tag or commit hash could not be retrieved from "{path}": fatal: Not a git repository~i', ['{path}' => $this->tmp]);
+        $this->expectExceptionMessageMatches($regex);
+        $this->expectException(RuntimeException::class);
+        $this->setConfig([
+            'git' => 'git',
+        ]);
     }
 
     public function test_a_recommendation_is_given_if_the_configured_git_placeholder_is_the_default_value(): void

--- a/tests/Console/Command/InfoTest.php
+++ b/tests/Console/Command/InfoTest.php
@@ -229,6 +229,9 @@ class InfoTest extends CommandTestCase
 
     public function test_it_provides_info_about_a_tarbz2_phar(): void
     {
+        if (!extension_loaded('bz2')) {
+            $this->markTestSkipped("This test requires php-bz2");
+        }
         $pharPath = self::FIXTURES.'/simple-phar.tar.bz2';
 
         $this->commandTester->execute(
@@ -295,6 +298,10 @@ class InfoTest extends CommandTestCase
 
     public function test_it_provides_a_phar_info_with_the_tree_of_the_content(): void
     {
+        if (!extension_loaded('bz2')) {
+            $this->markTestSkipped("This test requires php-bz2");
+        }
+
         $pharPath = self::FIXTURES.'/tree-phar.phar';
         $phar = new Phar($pharPath);
 
@@ -341,6 +348,10 @@ class InfoTest extends CommandTestCase
 
     public function test_it_provides_a_phar_info_with_the_flat_tree_of_the_content(): void
     {
+        if (!extension_loaded('bz2')) {
+            $this->markTestSkipped("This test requires php-bz2");
+        }
+
         $pharPath = self::FIXTURES.'/tree-phar.phar';
         $phar = new Phar($pharPath);
 
@@ -443,6 +454,10 @@ class InfoTest extends CommandTestCase
         ?string $depth,
         mixed $expected,
     ): void {
+        if (!extension_loaded('bz2')) {
+            $this->markTestSkipped("This test requires php-bz2");
+        }
+
         $pharPath = self::FIXTURES.'/tree-phar.phar';
         $phar = new Phar($pharPath);
 
@@ -603,6 +618,10 @@ class InfoTest extends CommandTestCase
 
     public function test_it_can_limit_the_tree_depth_in_flat_mode(): void
     {
+        if (!extension_loaded('bz2')) {
+            $this->markTestSkipped("This test requires php-bz2");
+        }
+
         $pharPath = self::FIXTURES.'/tree-phar.phar';
         $phar = new Phar($pharPath);
 


### PR DESCRIPTION
Fixes #706 and implements #564.

Also reworked tests to not be so closely coupled to implementation.
Instead:
- Tests now confirm the correct base image is chosen
- All required extensions are present in the docker file

Validating generated Dockerfiles and attempting to build them should be done in an integration test not in a unit test.