### PR TITLE
Update homebrew installation instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -50,7 +50,7 @@ $ vendor/bin/box
 To install box using [Homebrew](https://brew.sh), you need to tap the box formula first
 
 ```bash
-$ brew tap humbug/box
+$ brew tap box-project/box
 $ brew install box
 ```
 


### PR DESCRIPTION
Even though the instructions work right now (because Github redirects to the correct URL), it may be more reflective of the Github username to update the URL in the brew tap command.