### PR TITLE
ci: Refactor the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 
 on:
     push:
@@ -11,10 +11,6 @@ jobs:
     build-phar:
         runs-on: ubuntu-latest
         name: Build PHAR
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [ '8.1' ]
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3
@@ -24,7 +20,7 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.php }}
+                    php-version: '8.1'
                     ini-values: phar.readonly=0
                     tools: composer
                     coverage: none
@@ -75,7 +71,7 @@ jobs:
 
     publish-phar:
         runs-on: ubuntu-latest
-        name: Publish the PHAR
+        name: Publish PHAR
         needs:
             - 'build-phar'
         if: github.event_name == 'release'


### PR DESCRIPTION
- Rename the workflow from "build" to "release" to match PHP-Scoper.
- In-line the PHP version to no longer have the title changing with the PHP version used.