### PR TITLE
chore(makefile): Fix the coverage generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,15 +338,15 @@ vendor-bin/infection/composer.lock: vendor-bin/infection/composer.json
 	@echo "$(ERROR_COLOR)$(@) is not up to date. You may want to run the following command:$(NO_COLOR)"
 	@echo "$$ composer bin infection update --lock && touch -c $(@)"
 
-$(COVERAGE_XML_DIR): $(PHPUNIT_BIN) dist $(PHPUNIT_TEST_SRC) $(INFECTION_SRC)
-	$(PHPUNIT_COVERAGE_INFECTION)
-	touch -c $@
-	touch -c $(COVERAGE_JUNIT)
+$(COVERAGE_XML_DIR): $(PHPUNIT_BIN) $(PHPUNIT_TEST_SRC) $(INFECTION_SRC)
+	@# Do not include dist in the pre-requisite: we do want it to exist but its timestamp should not be tracked
+	$(MAKE) dist
+	$(MAKE) phpunit_coverage_infection
 
-$(COVERAGE_JUNIT): $(PHPUNIT_BIN) dist $(PHPUNIT_TEST_SRC) $(INFECTION_SRC)
-	$(PHPUNIT_COVERAGE_INFECTION)
-	touch -c $@
-	touch -c $(COVERAGE_XML_DIR)
+$(COVERAGE_JUNIT): $(PHPUNIT_BIN) $(PHPUNIT_TEST_SRC) $(INFECTION_SRC)
+	@# Do not include dist in the pre-requisite: we do want it to exist but its timestamp should not be tracked
+	$(MAKE) dist
+	$(MAKE) phpunit_coverage_infection
 
 fixtures/composer-dump/dir001/vendor: fixtures/composer-dump/dir001/composer.lock
 	composer install --ansi --working-dir=fixtures/composer-dump/dir001


### PR DESCRIPTION
- Simplify the rule for generating the coverage
- Fix the timestamp detection to not re-generate the coverage when running `make _infection` or `make infection_ci`