### PR TITLE
build: Add auto-review tests to ensure the E2E tests are in sync with  the GitHub Actions config

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -48,6 +48,7 @@ jobs:
                     - e2e_scoper_expose_symbols
                     - e2e_symfony
                     - e2e_composer_installed_versions
+                    - e2e_phpstorm_stubs
                 php: [ '8.1' ]
                 tools: [ composer ]
         steps:

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "mikey179/vfsstream": "^1.6.11",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.5.26",
-        "symfony/phpunit-bridge": "^4.2 || ^5.4.14 || ^6.1.6"
+        "symfony/phpunit-bridge": "^4.2 || ^5.4.14 || ^6.1.6",
+        "symfony/yaml": "^6.2"
     },
     "replace": {
         "paragonie/sodium_compat": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc833bd358a50deb50e6543161faa27b",
+    "content-hash": "52c488b95d6761320b64e7186b5fdc2e",
     "packages": [
         {
             "name": "amphp/amp",
@@ -5390,6 +5390,80 @@
                 }
             ],
             "time": "2022-10-07T08:04:03+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "2bbfbdacc8a15574f8440c4838ce0d7bb6c86b19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2bbfbdacc8a15574f8440c4838ce0d7bb6c86b19",
+                "reference": "2bbfbdacc8a15574f8440c4838ce0d7bb6c86b19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-10T18:53:53+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/requirement-checker/composer.json
+++ b/requirement-checker/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.29",
         "fidry/makefile": "^0.2.1",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0",
+        "symfony/yaml": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/requirement-checker/composer.lock
+++ b/requirement-checker/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b70b937dee36b762c428df9b40c1d4f",
+    "content-hash": "4320befde0ee29cb238d2c58d1f61b9f",
     "packages": [
         {
             "name": "composer/semver",
@@ -2459,6 +2459,88 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
             "name": "symfony/polyfill-php80",
             "version": "v1.27.0",
             "source": {
@@ -2619,6 +2701,80 @@
                 }
             ],
             "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "2bbfbdacc8a15574f8440c4838ce0d7bb6c86b19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2bbfbdacc8a15574f8440c4838ce0d7bb6c86b19",
+                "reference": "2bbfbdacc8a15574f8440c4838ce0d7bb6c86b19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-10T18:53:53+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/requirement-checker/tests/AutoReview/E2EMakefileTest.php
+++ b/requirement-checker/tests/AutoReview/E2EMakefileTest.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 
 namespace AutoReview;
 
-use Fidry\Makefile\Parser;
 use Fidry\Makefile\Rule;
 use Fidry\Makefile\Test\BaseMakefileTestCase;
-use function Safe\file_get_contents;
+use KevinGH\RequirementChecker\AutoReview\MakefileE2ECollector;
 
 /**
  * @coversNothing
@@ -40,7 +39,7 @@ final class E2EMakefileTest extends BaseMakefileTestCase
 
     public function test_the_e2e_target_must_contain_all_the_e2e_targets(): void
     {
-        $e2eRule = self::getE2ERule();
+        $e2eRule = MakefileE2ECollector::getE2ERule();
         $e2eTestTargets = self::getE2ETestRules();
 
         $e2eRulePrerequisites = $e2eRule->getPrerequisites();
@@ -54,18 +53,6 @@ final class E2EMakefileTest extends BaseMakefileTestCase
             array_map(
                 static fn (Rule $rule) => $rule->getTarget(),
                 $e2eTestTargets,
-            ),
-        );
-    }
-
-    private static function getE2ERule(): Rule
-    {
-        return current(
-            array_filter(
-                Parser::parse(
-                    file_get_contents(MakefileTest::MAKEFILE_PATH),
-                ),
-                static fn (Rule $rule) => 'test_e2e' === $rule->getTarget() && !$rule->isComment() && !$rule->isPhony(),
             ),
         );
     }

--- a/requirement-checker/tests/AutoReview/E2EMakefileTest.php
+++ b/requirement-checker/tests/AutoReview/E2EMakefileTest.php
@@ -16,7 +16,6 @@ namespace KevinGH\RequirementChecker\AutoReview;
 
 use Fidry\Makefile\Rule;
 use Fidry\Makefile\Test\BaseMakefileTestCase;
-use KevinGH\RequirementChecker\AutoReview\MakefileE2ECollector;
 
 /**
  * @coversNothing

--- a/requirement-checker/tests/AutoReview/GAE2ECollector.php
+++ b/requirement-checker/tests/AutoReview/GAE2ECollector.php
@@ -3,32 +3,27 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the humbug/php-scoper package.
+ * This file is part of the box project.
  *
- * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
- *                    Pádraic Brady <padraic.brady@gmail.com>
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
-namespace KevinGH\Box\AutoReview;
+namespace KevinGH\RequirementChecker\AutoReview;
 
-use Humbug\PhpScoper\NotInstantiable;
 use Symfony\Component\Yaml\Yaml;
+use function array_column;
 use function sort;
-use function str_starts_with;
-use function substr;
 use const SORT_STRING;
 
 final class GAE2ECollector
 {
-    use NotInstantiable;
+    private const GA_FILE = __DIR__.'/../../../.github/workflows/requirement-checker.yaml';
 
-    private const GA_FILE = __DIR__.'/../../.github/workflows/e2e-tests.yaml';
-
-    private const JOB_NAMES = 'e2e-tests';
-    private const DOCKER_JOB_NAME = 'e2e-tests-docker';
+    private const JOB_NAME = 'e2e-tests';
 
     /**
      * @return list<string>
@@ -51,19 +46,7 @@ final class GAE2ECollector
     {
         $parsedYaml = Yaml::parseFile(self::GA_FILE);
 
-        $names = [
-            ...self::findMatrixTests($parsedYaml['jobs'][self::JOB_NAMES]),
-        ];
-
-        foreach (self::findMatrixTests($parsedYaml['jobs'][self::DOCKER_JOB_NAME]) as $name) {
-            $names[] = str_starts_with($name, '_')
-                ? substr($name, 1)
-                : $name;
-        }
-
-        sort($names, SORT_STRING);
-
-        return $names;
+        return self::findMatrixTests($parsedYaml['jobs'][self::JOB_NAME]);
     }
 
     /**
@@ -72,7 +55,10 @@ final class GAE2ECollector
     private static function findMatrixTests(array $job): array
     {
         /** @var string[] $names */
-        $names = $job['strategy']['matrix']['e2e'];
+        $names = array_column(
+            $job['strategy']['matrix']['e2e'],
+            'command',
+        );
 
         sort($names, SORT_STRING);
 

--- a/requirement-checker/tests/AutoReview/GAE2ECollector.php
+++ b/requirement-checker/tests/AutoReview/GAE2ECollector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KevinGH\Box\AutoReview;
+
+use Humbug\PhpScoper\NotInstantiable;
+use Symfony\Component\Yaml\Yaml;
+use function sort;
+use function str_starts_with;
+use function substr;
+use const SORT_STRING;
+
+final class GAE2ECollector
+{
+    use NotInstantiable;
+
+    private const GA_FILE = __DIR__.'/../../.github/workflows/e2e-tests.yaml';
+
+    private const JOB_NAMES = 'e2e-tests';
+    private const DOCKER_JOB_NAME = 'e2e-tests-docker';
+
+    /**
+     * @return list<string>
+     */
+    public static function getExecutedE2ETests(): array
+    {
+        static $names;
+
+        if (!isset($names)) {
+            $names = self::findE2ENames();
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function findE2ENames(): array
+    {
+        $parsedYaml = Yaml::parseFile(self::GA_FILE);
+
+        $names = [
+            ...self::findMatrixTests($parsedYaml['jobs'][self::JOB_NAMES]),
+        ];
+
+        foreach (self::findMatrixTests($parsedYaml['jobs'][self::DOCKER_JOB_NAME]) as $name) {
+            $names[] = str_starts_with($name, '_')
+                ? substr($name, 1)
+                : $name;
+        }
+
+        sort($names, SORT_STRING);
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function findMatrixTests(array $job): array
+    {
+        /** @var string[] $names */
+        $names = $job['strategy']['matrix']['e2e'];
+
+        sort($names, SORT_STRING);
+
+        return $names;
+    }
+}

--- a/requirement-checker/tests/AutoReview/GAE2ECollectorTest.php
+++ b/requirement-checker/tests/AutoReview/GAE2ECollectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KevinGH\Box\AutoReview;
+
+use PHPUnit\Framework\TestCase;
+use function count;
+
+/**
+ * @covers \KevinGH\Box\AutoReview\GAE2ECollector
+ *
+ * @internal
+ */
+class GAE2ECollectorTest extends TestCase
+{
+    public function test_it_collects_the_e2e_test_names(): void
+    {
+        $names = GAE2ECollector::getExecutedE2ETests();
+
+        self::assertGreaterThan(0, count($names));
+
+        foreach ($names as $name) {
+            self::assertMatchesRegularExpression('/^e2e_[\p{L}_]+$/', $name);
+        }
+    }
+}

--- a/requirement-checker/tests/AutoReview/GAE2ECollectorTest.php
+++ b/requirement-checker/tests/AutoReview/GAE2ECollectorTest.php
@@ -3,16 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the humbug/php-scoper package.
+ * This file is part of the box project.
  *
- * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
- *                    Pádraic Brady <padraic.brady@gmail.com>
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
-namespace KevinGH\Box\AutoReview;
+namespace KevinGH\RequirementChecker\AutoReview;
 
 use PHPUnit\Framework\TestCase;
 use function count;
@@ -31,7 +31,7 @@ class GAE2ECollectorTest extends TestCase
         self::assertGreaterThan(0, count($names));
 
         foreach ($names as $name) {
-            self::assertMatchesRegularExpression('/^e2e_[\p{L}_]+$/', $name);
+            self::assertMatchesRegularExpression('/^_?test_e2e_[\p{L}_]+$/', $name);
         }
     }
 }

--- a/requirement-checker/tests/AutoReview/GAE2ETest.php
+++ b/requirement-checker/tests/AutoReview/GAE2ETest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\AutoReview;
+
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class GAE2ETest extends TestCase
+{
+    public function test_github_actions_executes_all_the_e2e_tests(): void
+    {
+        $expected = MakefileE2ECollector::getE2ERule()->getPrerequisites();
+        $actual = GAE2ECollector::getExecutedE2ETests();
+
+        self::assertEqualsCanonicalizing($expected, $actual);
+    }
+}

--- a/requirement-checker/tests/AutoReview/GAE2ETest.php
+++ b/requirement-checker/tests/AutoReview/GAE2ETest.php
@@ -2,21 +2,35 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\AutoReview;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\RequirementChecker\AutoReview;
 
 use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
+ *
+ * @internal
  */
 final class GAE2ETest extends TestCase
 {
     public function test_github_actions_executes_all_the_e2e_tests(): void
     {
-        $expected = MakefileE2ECollector::getE2ERule()->getPrerequisites();
+        $e2eRule = MakefileE2ECollector::getE2ERule();
+        $e2eRulePrerequisites = $e2eRule->getPrerequisites();
+        array_shift($e2eRulePrerequisites);   // Remove docker-images
+
         $actual = GAE2ECollector::getExecutedE2ETests();
 
-        self::assertEqualsCanonicalizing($expected, $actual);
+        self::assertEqualsCanonicalizing($e2eRulePrerequisites, $actual);
     }
 }

--- a/requirement-checker/tests/AutoReview/MakefileE2ECollector.php
+++ b/requirement-checker/tests/AutoReview/MakefileE2ECollector.php
@@ -12,16 +12,15 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace KevinGH\Box\AutoReview;
+namespace KevinGH\RequirementChecker\AutoReview;
 
+use AutoReview\MakefileTest;
 use Fidry\Makefile\Parser;
 use Fidry\Makefile\Rule;
-use Humbug\PhpScoper\NotInstantiable;
+use function current;
 
 final class MakefileE2ECollector
 {
-    use NotInstantiable;
-
     public static function getE2ERule(): Rule
     {
         static $e2eRule;

--- a/requirement-checker/tests/AutoReview/MakefileE2ECollector.php
+++ b/requirement-checker/tests/AutoReview/MakefileE2ECollector.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace KevinGH\RequirementChecker\AutoReview;
 
-use AutoReview\MakefileTest;
 use Fidry\Makefile\Parser;
 use Fidry\Makefile\Rule;
 use function current;

--- a/tests/AutoReview/E2EMakefileTest.php
+++ b/tests/AutoReview/E2EMakefileTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\AutoReview;
 
-use Fidry\Makefile\Parser;
 use Fidry\Makefile\Rule;
 use Fidry\Makefile\Test\BaseMakefileTestCase;
 

--- a/tests/AutoReview/E2EMakefileTest.php
+++ b/tests/AutoReview/E2EMakefileTest.php
@@ -39,7 +39,7 @@ final class E2EMakefileTest extends BaseMakefileTestCase
 
     public function test_the_e2e_target_must_contain_all_the_e2e_targets(): void
     {
-        $e2eRule = self::getE2ERule();
+        $e2eRule = MakefileE2ECollector::getE2ERule();
         $e2eTestTargets = self::getE2ETestRules();
 
         $e2eRulePrerequisites = $e2eRule->getPrerequisites();
@@ -56,20 +56,8 @@ final class E2EMakefileTest extends BaseMakefileTestCase
         );
     }
 
-    private static function getE2ERule(): Rule
-    {
-        return current(
-            array_filter(
-                Parser::parse(
-                    file_get_contents(MakefileTest::MAKEFILE_PATH),
-                ),
-                static fn (Rule $rule) => 'test_e2e' === $rule->getTarget() && !$rule->isComment() && !$rule->isPhony(),
-            ),
-        );
-    }
-
     /**
-     * @return Rule
+     * @return list<Rule>
      */
     private static function getE2ETestRules(): array
     {

--- a/tests/AutoReview/GAE2ECollector.php
+++ b/tests/AutoReview/GAE2ECollector.php
@@ -3,28 +3,24 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the humbug/php-scoper package.
+ * This file is part of the box project.
  *
- * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
- *                    Pádraic Brady <padraic.brady@gmail.com>
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 namespace KevinGH\Box\AutoReview;
 
-use Humbug\PhpScoper\NotInstantiable;
 use Symfony\Component\Yaml\Yaml;
 use function sort;
 use function str_starts_with;
-use function substr;
 use const SORT_STRING;
 
 final class GAE2ECollector
 {
-    use NotInstantiable;
-
     private const GA_FILE = __DIR__.'/../../.github/workflows/e2e-tests.yaml';
 
     private const JOB_NAMES = 'e2e-tests';
@@ -57,7 +53,7 @@ final class GAE2ECollector
 
         foreach (self::findMatrixTests($parsedYaml['jobs'][self::DOCKER_JOB_NAME]) as $name) {
             $names[] = str_starts_with($name, '_')
-                ? substr($name, 1)
+                ? mb_substr($name, 1)
                 : $name;
         }
 

--- a/tests/AutoReview/GAE2ECollector.php
+++ b/tests/AutoReview/GAE2ECollector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KevinGH\Box\AutoReview;
+
+use Humbug\PhpScoper\NotInstantiable;
+use Symfony\Component\Yaml\Yaml;
+use function sort;
+use function str_starts_with;
+use function substr;
+use const SORT_STRING;
+
+final class GAE2ECollector
+{
+    use NotInstantiable;
+
+    private const GA_FILE = __DIR__.'/../../.github/workflows/e2e-tests.yaml';
+
+    private const JOB_NAMES = 'e2e-tests';
+    private const DOCKER_JOB_NAME = 'e2e-tests-docker';
+
+    /**
+     * @return list<string>
+     */
+    public static function getExecutedE2ETests(): array
+    {
+        static $names;
+
+        if (!isset($names)) {
+            $names = self::findE2ENames();
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function findE2ENames(): array
+    {
+        $parsedYaml = Yaml::parseFile(self::GA_FILE);
+
+        $names = [
+            ...self::findMatrixTests($parsedYaml['jobs'][self::JOB_NAMES]),
+        ];
+
+        foreach (self::findMatrixTests($parsedYaml['jobs'][self::DOCKER_JOB_NAME]) as $name) {
+            $names[] = str_starts_with($name, '_')
+                ? substr($name, 1)
+                : $name;
+        }
+
+        sort($names, SORT_STRING);
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function findMatrixTests(array $job): array
+    {
+        /** @var string[] $names */
+        $names = $job['strategy']['matrix']['e2e'];
+
+        sort($names, SORT_STRING);
+
+        return $names;
+    }
+}

--- a/tests/AutoReview/GAE2ECollectorTest.php
+++ b/tests/AutoReview/GAE2ECollectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KevinGH\Box\AutoReview;
+
+use PHPUnit\Framework\TestCase;
+use function count;
+
+/**
+ * @covers \KevinGH\Box\AutoReview\GAE2ECollector
+ *
+ * @internal
+ */
+class GAE2ECollectorTest extends TestCase
+{
+    public function test_it_collects_the_e2e_test_names(): void
+    {
+        $names = GAE2ECollector::getExecutedE2ETests();
+
+        self::assertGreaterThan(0, count($names));
+
+        foreach ($names as $name) {
+            self::assertMatchesRegularExpression('/^e2e_[\p{L}_]+$/', $name);
+        }
+    }
+}

--- a/tests/AutoReview/GAE2ECollectorTest.php
+++ b/tests/AutoReview/GAE2ECollectorTest.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the humbug/php-scoper package.
+ * This file is part of the box project.
  *
- * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
- *                    Pádraic Brady <padraic.brady@gmail.com>
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 namespace KevinGH\Box\AutoReview;

--- a/tests/AutoReview/GAE2ETest.php
+++ b/tests/AutoReview/GAE2ETest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\AutoReview;
+
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class GAE2ETest extends TestCase
+{
+    public function test_github_actions_executes_all_the_e2e_tests(): void
+    {
+        $expected = MakefileE2ECollector::getE2ERule()->getPrerequisites();
+        $actual = GAE2ECollector::getExecutedE2ETests();
+
+        self::assertEqualsCanonicalizing($expected, $actual);
+    }
+}

--- a/tests/AutoReview/GAE2ETest.php
+++ b/tests/AutoReview/GAE2ETest.php
@@ -2,13 +2,24 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\AutoReview;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box\AutoReview;
 
 use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
+ *
+ * @internal
  */
 final class GAE2ETest extends TestCase
 {

--- a/tests/AutoReview/MakefileE2ECollector.php
+++ b/tests/AutoReview/MakefileE2ECollector.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KevinGH\Box\AutoReview;
+
+use Fidry\Makefile\Parser;
+use Fidry\Makefile\Rule;
+use Humbug\PhpScoper\NotInstantiable;
+use Symfony\Component\Yaml\Yaml;
+use function sort;
+use function str_starts_with;
+use function substr;
+use const SORT_STRING;
+
+final class MakefileE2ECollector
+{
+    use NotInstantiable;
+
+    public static function getE2ERule(): Rule
+    {
+        static $e2eRule;
+
+        if (!isset($e2eRule)) {
+            $e2eRule = self::findE2ERule();
+        }
+
+        return $e2eRule;
+    }
+
+    private static function findE2ERule(): Rule
+    {
+        return current(
+            array_filter(
+                Parser::parse(
+                    file_get_contents(MakefileTest::MAKEFILE_PATH),
+                ),
+                static fn (Rule $rule) => 'test_e2e' === $rule->getTarget() && !$rule->isComment() && !$rule->isPhony(),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
We already have tests to ensure the e2e Makefile target executes all the known e2e target, but we were missing a similar check for GitHub Actions.