### PR TITLE
fix: Correctly disable the annotation compacting when configuring `annotations=false`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
             "src/functions.php"
         ],
         "exclude-from-classmap": [
-            "/Test/"
+            "/Test/",
+            "vendor/humbug/php-scoper/vendor-hotfix"
         ]
     },
     "autoload-dev": {

--- a/src/Compactor/Php.php
+++ b/src/Compactor/Php.php
@@ -47,7 +47,7 @@ use const T_WHITESPACE;
 final class Php extends FileExtensionCompactor
 {
     public function __construct(
-        private DocblockAnnotationParser $annotationParser,
+        private ?DocblockAnnotationParser $annotationParser,
         array $extensions = ['php'],
     ) {
         parent::__construct($extensions);
@@ -136,6 +136,10 @@ final class Php extends FileExtensionCompactor
 
     private function compactAnnotations(string $docblock): string
     {
+        if (null === $this->annotationParser) {
+            return $docblock;
+        }
+
         $breaksNbr = mb_substr_count($docblock, "\n");
 
         $annotations = $this->annotationParser->parse($docblock);

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -1726,8 +1726,8 @@ final class Configuration
     }
 
     /**
-     * @param string[] $compactorClasses
-     * @param string[] $ignoredAnnotations
+     * @param string[]      $compactorClasses
+     * @param string[]|null $ignoredAnnotations
      *
      * @return Compactor[]
      */
@@ -1735,7 +1735,7 @@ final class Configuration
         stdClass $raw,
         string $basePath,
         array $compactorClasses,
-        array $ignoredAnnotations,
+        ?array $ignoredAnnotations,
         ConfigurationLogger $logger,
     ): array {
         return array_map(
@@ -2643,13 +2643,13 @@ final class Configuration
     /**
      * @param string[] $compactorClasses
      *
-     * @return string[]
+     * @return string[]|null
      */
     private static function retrievePhpCompactorIgnoredAnnotations(
         stdClass $raw,
         array $compactorClasses,
         ConfigurationLogger $logger,
-    ): array {
+    ): ?array {
         $hasPhpCompactor = in_array(PhpCompactor::class, $compactorClasses, true);
 
         self::checkIfDefaultValue($logger, $raw, self::ANNOTATIONS_KEY, true);
@@ -2676,7 +2676,7 @@ final class Configuration
         }
 
         if (false === $annotations) {
-            return [];
+            return null;
         }
 
         if (false === property_exists($annotations, self::IGNORED_ANNOTATIONS_KEY)) {
@@ -2690,7 +2690,7 @@ final class Configuration
                 ),
             );
 
-            return [];
+            return null;
         }
 
         $ignored = [];
@@ -2706,8 +2706,12 @@ final class Configuration
         return $ignored;
     }
 
-    private static function createPhpCompactor(array $ignoredAnnotations): Compactor
+    private static function createPhpCompactor(?array $ignoredAnnotations): Compactor
     {
+        if (null === $ignoredAnnotations) {
+            return new PhpCompactor(null);
+        }
+
         $ignoredAnnotations = array_values(
             array_filter(
                 array_map(

--- a/tests/Annotation/DocblockAnnotationParserTest.php
+++ b/tests/Annotation/DocblockAnnotationParserTest.php
@@ -80,5 +80,21 @@ class DocblockAnnotationParserTest extends TestCase
                 DOCBLOCK,
             ['@Kept'],
         ];
+
+        yield [
+            <<<'DOCBLOCK'
+                /**
+                 * A foo version.
+                 *
+                 * @var string
+                 *
+                 * @JMS\Type("string")
+                 */
+                DOCBLOCK,
+            [
+                '@var string',
+                '@JMS\Type("string")',
+            ],
+        ];
     }
 }

--- a/tests/Annotation/DocblockAnnotationParserTest.php
+++ b/tests/Annotation/DocblockAnnotationParserTest.php
@@ -92,7 +92,7 @@ class DocblockAnnotationParserTest extends TestCase
                  */
                 DOCBLOCK,
             [
-                '@var string',
+                '@var',
                 '@JMS\Type("string")',
             ],
         ];

--- a/tests/Configuration/ConfigurationPhpCompactorTest.php
+++ b/tests/Configuration/ConfigurationPhpCompactorTest.php
@@ -259,6 +259,58 @@ class ConfigurationPhpCompactorTest extends ConfigurationTestCase
         $falseAnnotationConfigs = [
             false,
             new stdClass(),
+        ];
+
+        foreach ($falseAnnotationConfigs as $config) {
+            yield [
+                [
+                    'annotations' => $config,
+                    'compactors' => [Php::class],
+                ],
+                <<<'PHP'
+                    <?php
+
+                    /**
+                     * Function comparing the two given values
+                     *
+                     * @param int $x
+                     * @param int $y
+                     *
+                     * @return int
+                     *
+                     * @author Théo Fidry
+                     * @LICENSE MIT
+                     *
+                     * @Acme(type = "function")
+                     */
+                    function foo($x, $y): int {
+                        return $x <=> $y;
+                    }
+                    PHP,
+                <<<'PHP'
+                    <?php
+
+                    /**
+                     * Function comparing the two given values
+                     *
+                     * @param int $x
+                     * @param int $y
+                     *
+                     * @return int
+                     *
+                     * @author Théo Fidry
+                     * @LICENSE MIT
+                     *
+                     * @Acme(type = "function")
+                     */
+                    function foo($x, $y): int {
+                    return $x <=> $y;
+                    }
+                    PHP,
+            ];
+        }
+
+        $noIgnoredTagAnnotationConfigs = [
             (object) [
                 'ignore' => [],
             ],
@@ -267,7 +319,7 @@ class ConfigurationPhpCompactorTest extends ConfigurationTestCase
             ],
         ];
 
-        foreach ($falseAnnotationConfigs as $config) {
+        foreach ($noIgnoredTagAnnotationConfigs as $config) {
             yield [
                 [
                     'annotations' => $config,


### PR DESCRIPTION


Closes #566.