### PR TITLE
refactor: Simplify the exported configuration

### DIFF
--- a/src/Configuration/ExportableConfiguration.php
+++ b/src/Configuration/ExportableConfiguration.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Configuration;
+
+use Closure;
+use KevinGH\Box\Compactor\Compactors;
+use KevinGH\Box\Composer\ComposerFile;
+use KevinGH\Box\MapFile;
+use Phar;
+use SplFileInfo;
+use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use function array_flip;
+use function array_map;
+use function iter\values;
+use function KevinGH\Box\FileSystem\make_path_relative;
+use function KevinGH\Box\get_phar_compression_algorithms;
+use function KevinGH\Box\get_phar_signing_algorithms;
+use function sort;
+use const SORT_STRING;
+
+/**
+ * A class similar to {@see Configuration} but for which the property types and values might change in order to improve
+ * its readability when dumping it into a file.
+ *
+ * @internal
+ */
+final class ExportableConfiguration
+{
+    public static function create(Configuration $configuration): self
+    {
+        $normalizePath = self::createPathNormalizer($configuration->getBasePath());
+        $normalizePaths = static function (array $files) use ($normalizePath): array {
+            $files = array_map($normalizePath, $files);
+            sort($files, SORT_STRING);
+
+            return $files;
+        };
+
+        $composerJson = $configuration->getComposerJson();
+        $composerLock = $configuration->getComposerLock();
+
+        return new self(
+            $normalizePath($configuration->getConfigurationFile()),
+            $configuration->getAlias(),
+            $configuration->getBasePath(),
+            new ComposerFile(
+                $normalizePath($composerJson),
+                $configuration->getDecodedComposerJsonContents() ?? [],
+            ),
+            new ComposerFile(
+                $normalizePath($composerLock),
+                $configuration->getDecodedComposerLockContents() ?? [],
+            ),
+            $normalizePaths($configuration->getFiles()),
+            $normalizePaths($configuration->getBinaryFiles()),
+            $configuration->hasAutodiscoveredFiles(),
+            $configuration->dumpAutoload(),
+            $configuration->excludeComposerFiles(),
+            $configuration->excludeDevFiles(),
+            array_map('get_class', $configuration->getCompactors()->toArray()),
+            array_flip(get_phar_compression_algorithms())[$configuration->getCompressionAlgorithm() ?? Phar::NONE],
+            '0'.decoct($configuration->getFileMode()),
+            $normalizePath($configuration->getMainScriptPath()),
+            $configuration->getMainScriptContents(),
+            $configuration->getFileMapper(),
+            $configuration->getMetadata(),
+            $normalizePath($configuration->getTmpOutputPath()),
+            $normalizePath($configuration->getOutputPath()),
+            // TODO: remove this from the dump & add the SensitiveParam annotation
+            $configuration->getPrivateKeyPassphrase(),
+            $normalizePath($configuration->getPrivateKeyPath()),
+            $configuration->promptForPrivateKey(),
+            $configuration->getReplacements(),
+            $configuration->getShebang(),
+            array_flip(get_phar_signing_algorithms())[$configuration->getSigningAlgorithm()],
+            $configuration->getStubBannerContents(),
+            $normalizePath($configuration->getStubBannerPath()),
+            $normalizePath($configuration->getStubPath()),
+            $configuration->isInterceptFileFuncs(),
+            $configuration->isStubGenerated(),
+            $configuration->checkRequirements(),
+            $configuration->getWarnings(),
+            $configuration->getRecommendations(),
+        );
+    }
+
+    /**
+     * @return Closure(null|SplFileInfo|string): string|null
+     */
+    private static function createPathNormalizer(string $basePath): Closure
+    {
+        return static function (null|SplFileInfo|string $path) use ($basePath): ?string {
+            if (null === $path) {
+                return null;
+            }
+
+            if ($path instanceof SplFileInfo) {
+                $path = $path->getPathname();
+            }
+
+            return make_path_relative($path, $basePath);
+        };
+    }
+
+    /** @noinspection PhpPropertyOnlyWrittenInspection */
+    private function __construct(
+        private readonly ?string $file,
+        private readonly string $alias,
+        private readonly string $basePath,
+        private readonly ComposerFile $composerJson,
+        private readonly ComposerFile $composerLock,
+        private readonly array $files,
+        private readonly array $binaryFiles,
+        private readonly bool $autodiscoveredFiles,
+        private readonly bool $dumpAutoload,
+        private readonly bool $excludeComposerFiles,
+        private readonly bool $excludeDevFiles,
+        private readonly Compactors|array $compactors,
+        private readonly string $compressionAlgorithm,
+        private readonly int|string|null $fileMode,
+        private readonly ?string $mainScriptPath,
+        private readonly ?string $mainScriptContents,
+        private readonly MapFile $fileMapper,
+        private readonly mixed $metadata,
+        private readonly string $tmpOutputPath,
+        private readonly string $outputPath,
+        private readonly ?string $privateKeyPassphrase,
+        private readonly ?string $privateKeyPath,
+        private readonly bool $promptForPrivateKey,
+        private readonly array $processedReplacements,
+        private readonly ?string $shebang,
+        private readonly string $signingAlgorithm,
+        private readonly ?string $stubBannerContents,
+        private readonly ?string $stubBannerPath,
+        private readonly ?string $stubPath,
+        private readonly bool $isInterceptFileFuncs,
+        private readonly bool $isStubGenerated,
+        private readonly bool $checkRequirements,
+        private readonly array $warnings,
+        private readonly array $recommendations,
+    ) {
+    }
+
+    public function export(): string
+    {
+        $cloner = new VarCloner();
+        $cloner->setMaxItems(-1);
+        $cloner->setMaxString(-1);
+
+        $normalizePath = self::createPathNormalizer($this->basePath);
+        $splInfoCaster = static fn (SplFileInfo $fileInfo): array => [$normalizePath($fileInfo)];
+
+        $cloner->addCasters([
+            SplFileInfo::class => $splInfoCaster,
+            SymfonySplFileInfo::class => $splInfoCaster,
+        ]);
+
+        return (new CliDumper())->dump(
+            $cloner->cloneVar($this),
+            true,
+        );
+    }
+}

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -2959,10 +2959,7 @@ class ConfigurationTest extends ConfigurationTestCase
         ]);
 
         $expectedDumpedConfig = <<<'EOF'
-            KevinGH\Box\Configuration\Configuration {#100
-              -compressionAlgorithm: "GZ"
-              -mainScriptPath: "index.php"
-              -mainScriptContents: ""
+            KevinGH\Box\Configuration\ExportableConfiguration {#100
               -file: "box.json"
               -alias: "test.phar"
               -basePath: "/path/to"
@@ -3001,7 +2998,10 @@ class ConfigurationTest extends ConfigurationTestCase
               -compactors: array:1 [
                 0 => "KevinGH\Box\Compactor\Php"
               ]
+              -compressionAlgorithm: "GZ"
               -fileMode: "0755"
+              -mainScriptPath: "index.php"
+              -mainScriptContents: ""
               -fileMapper: KevinGH\Box\MapFile {#100
                 -basePath: "/path/to"
                 -map: []

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1208,16 +1208,7 @@ class CompileTest extends FileSystemTestCase
             // Time: 2018-05-24T20:59:15+00:00
             //
 
-            KevinGH\Box\Configuration\Configuration {#140
-              -compressionAlgorithm: "NONE"
-              -mainScriptPath: "index.php"
-              -mainScriptContents: """
-                <?php\n
-                \n
-                declare(strict_types=1);\n
-                \n
-                echo 'Yo';\n
-                """
+            KevinGH\Box\Configuration\ExportableConfiguration {#140
               -file: "box.json"
               -alias: "index.phar"
               -basePath: "/path/to"
@@ -1236,7 +1227,16 @@ class CompileTest extends FileSystemTestCase
               -excludeComposerFiles: true
               -excludeDevFiles: false
               -compactors: []
+              -compressionAlgorithm: "NONE"
               -fileMode: "0755"
+              -mainScriptPath: "index.php"
+              -mainScriptContents: """
+                <?php\n
+                \n
+                declare(strict_types=1);\n
+                \n
+                echo 'Yo';\n
+                """
               -fileMapper: KevinGH\Box\MapFile {#140
                 -basePath: "/path/to"
                 -map: []


### PR DESCRIPTION
Create a dedicated class for exporting the Configuration. This allows two things:

- Trim down a bit `Configuration` which is already quite big
- Have better type-safety since the types desired for the exported configuration differ from the regular configuration and having them in one means widening those types making the usage less type-safe.