### PR TITLE
feat: Deprecate explicitely enabling the requirement checker when the composer.lock could not be found.

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -2461,6 +2461,7 @@ final class Configuration
         /** @var bool $checkRequirements */
         $checkRequirements = $raw->{self::CHECK_REQUIREMENTS_KEY} ?? true;
 
+        // TODO: in 5.0 we no longer care about the composer.json
         if ($checkRequirements && false === $hasComposerJson && false === $hasComposerLock) {
             $logger->addWarning(
                 'The requirement checker could not be used because the composer.json and composer.lock file could not '
@@ -2468,6 +2469,16 @@ final class Configuration
             );
 
             return false;
+        }
+
+        if ($checkRequirements && false === $hasComposerLock) {
+            // TODO: in 5.0:
+            //  - adjust the warning
+            //  - return false here to skip the requirement checker
+            $logger->addWarning(
+                'Enabling the requirement checker when there is no composer.lock is deprecated. In the future the '
+                .'requirement checker will be forcefully skipped in this scenario.',
+            );
         }
 
         if ($checkRequirements && $pharStubUsed) {


### PR DESCRIPTION
In some older versions of Composer the `composer.lock` file was not always generated. It is now, at the very least since 2.2, always generated.

Since the `composer.json` information is too lacking to provide a reliable result for the requirement checker (it does not contain the information about each package, hence what the packages requirements are or what extension they provide cannot be known), I want to deprecate using the requirement checker when the `composer.lock` file is not found.