### PR TITLE
fix: Use information from the composer.lock when possible for the requirement checker

### DIFF
--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -49,8 +49,8 @@ final class AppRequirementsFactory
         DecodedComposerJson $composerJson,
         DecodedComposerLock $composerLock,
     ): array {
-        // If the application config is set, it is the authority.
-        return $composerLock->isEmpty() && $composerJson->hasRequiredPhpVersion() || $composerLock->hasRequiredPhpVersion()
+        // If the application has a constraint on the PHP version, it is the authority.
+        return $composerLock->hasRequiredPhpVersion() || $composerJson->hasRequiredPhpVersion()
             ? self::retrievePHPRequirementFromPlatform($composerJson, $composerLock)
             : self::retrievePHPRequirementFromPackages($composerLock);
     }
@@ -62,9 +62,7 @@ final class AppRequirementsFactory
         DecodedComposerJson $composerJson,
         DecodedComposerLock $composerLock,
     ): array {
-        $requiredPhpVersion = $composerLock->isEmpty()
-            ? $composerJson->getRequiredPhpVersion()
-            : $composerLock->getRequiredPhpVersion();
+        $requiredPhpVersion = $composerLock->getRequiredPhpVersion() ?? $composerJson->getRequiredPhpVersion();
 
         return null === $requiredPhpVersion ? [] : [Requirement::forPHP($requiredPhpVersion, null)];
     }
@@ -148,7 +146,6 @@ final class AppRequirementsFactory
     }
 
     /**
-     * TODO: review: I am not sure this makes sense since there is no info about the packages used.
      * @param array<string, list<string>> $requirements The key is the extension name and the value the list of sources (app literal string or the package name).
      *
      * @return array{array<string, true>, array<string, string>}

--- a/tests/RequirementChecker/AppRequirementsFactoryTest.php
+++ b/tests/RequirementChecker/AppRequirementsFactoryTest.php
@@ -435,6 +435,127 @@ class AppRequirementsFactoryTest extends TestCase
             ],
         ];
 
+        yield 'The application defines a PHP requirement (takes it from the composer.lock)' => [
+            <<<'JSON'
+                {
+                    "require": {
+                        "php": ">=5.3"
+                    },
+                    "require-dev": []
+                }
+                JSON,
+            <<<'JSON'
+                {
+                    "platform": {
+                        "php": ">=5.4"
+                    },
+                    "packages": [
+                        {
+                            "name": "beberlei/assert",
+                            "version": "v2.9.2",
+                            "require": {
+                                "php": ">=5.3"
+                            },
+                            "require-dev": []
+                        },
+                        {
+                            "name": "composer/ca-bundle",
+                            "version": "1.1.0",
+                            "require": {},
+                            "require-dev": {
+                                "ext-pdo_sqlite3": "*"
+                            }
+                        }
+                    ]
+                }
+                JSON,
+            CompressionAlgorithm::NONE,
+            [
+                Requirement::forPHP('>=5.4', null),
+            ],
+        ];
+
+        yield 'The application defines a PHP requirement (takes it from the composer.json if the .lock does not have it)' => [
+            <<<'JSON'
+                {
+                    "require": {
+                        "php": ">=5.3"
+                    },
+                    "require-dev": []
+                }
+                JSON,
+            <<<'JSON'
+                {
+                    "packages": [
+                        {
+                            "name": "beberlei/assert",
+                            "version": "v2.9.2",
+                            "require": {
+                                "php": ">=5.3"
+                            },
+                            "require-dev": []
+                        },
+                        {
+                            "name": "composer/ca-bundle",
+                            "version": "1.1.0",
+                            "require": {},
+                            "require-dev": {
+                                "ext-pdo_sqlite3": "*"
+                            }
+                        }
+                    ]
+                }
+                JSON,
+            CompressionAlgorithm::NONE,
+            [
+                Requirement::forPHP('>=5.3', null),
+            ],
+        ];
+
+        yield 'The application does not define a PHP requirement (takes it from packages)' => [
+            <<<'JSON'
+                {
+                    "require": {},
+                    "require-dev": []
+                }
+                JSON,
+            <<<'JSON'
+                {
+                    "packages": [
+                        {
+                            "name": "beberlei/assert",
+                            "version": "v2.9.2",
+                            "require": {
+                                "php": ">=5.3"
+                            },
+                            "require-dev": []
+                        },
+                        {
+                            "name": "acme/foo",
+                            "version": "2.0.0",
+                            "require": {},
+                            "require-dev": {}
+                        },
+                        {
+                            "name": "composer/ca-bundle",
+                            "version": "1.1.0",
+                            "require": {
+                                "php": "^7.1"
+                            },
+                            "require-dev": {
+                                "ext-pdo_sqlite3": "*"
+                            }
+                        }
+                    ]
+                }
+                JSON,
+            CompressionAlgorithm::NONE,
+            [
+                Requirement::forPHP('>=5.3', 'beberlei/assert'),
+                Requirement::forPHP('^7.1', 'composer/ca-bundle'),
+            ],
+        ];
+
         yield 'json & lock file packages requirements' => [
             <<<'JSON'
                 {
@@ -486,8 +607,7 @@ class AppRequirementsFactoryTest extends TestCase
                 JSON,
             CompressionAlgorithm::NONE,
             [
-                Requirement::forPHP('>=5.3', 'beberlei/assert'),
-                Requirement::forPHP('^5.3.2 || ^7.0', 'acme/foo'),
+                Requirement::forPHP('>=5.3', null),
                 Requirement::forExtension('mbstring', 'beberlei/assert'),
                 Requirement::forExtension('openssl', 'composer/ca-bundle'),
                 Requirement::forExtension('openssl', 'acme/foo'),


### PR DESCRIPTION
As explained in #867, the `composer.json` provides only partial and incomplete information which is why it is preferable to use the `composer.lock` file instead.