### PR TITLE
fix: Take the polyfilled extensions from the "provide" package info

### DIFF
--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -185,9 +185,7 @@ final class AppRequirementsFactory
         $polyfills = [];
 
         foreach ($composerLock->getPackages() as $packageInfo) {
-            $polyfilledExtension = $packageInfo->getPolyfilledExtension();
-
-            if (null !== $polyfilledExtension) {
+            foreach ($packageInfo->getPolyfilledExtensions() as $polyfilledExtension) {
                 $polyfills[$polyfilledExtension] = true;
             }
 

--- a/src/RequirementChecker/PackageInfo.php
+++ b/src/RequirementChecker/PackageInfo.php
@@ -57,22 +57,29 @@ final class PackageInfo
         return self::parseExtensions($this->packageInfo['require'] ?? []);
     }
 
-    public function getPolyfilledExtension(): ?string
+    /**
+     * @return list<string>
+     */
+    public function getPolyfilledExtensions(): array
     {
-        // TODO: should read the "provide" section instead.
+        if (array_key_exists('provide', $this->packageInfo)) {
+            return self::parseExtensions($this->packageInfo['provide']);
+        }
+
+        // TODO: remove the following code in 5.0.
         $name = $this->packageInfo['name'];
 
         if (array_key_exists($name, self::POLYFILL_MAP)) {
-            return self::POLYFILL_MAP[$name];
+            return [self::POLYFILL_MAP[$name]];
         }
 
         if (1 !== preg_match(self::SYMFONY_POLYFILL_REGEX, $name, $matches)) {
-            return null;
+            return [];
         }
 
         $extension = $matches['extension'];
 
-        return str_starts_with($extension, 'php') ? null : $extension;
+        return str_starts_with($extension, 'php') ? [] : [$extension];
     }
 
     /**

--- a/tests/RequirementChecker/PackageInfoTest.php
+++ b/tests/RequirementChecker/PackageInfoTest.php
@@ -33,7 +33,7 @@ final class PackageInfoTest extends TestCase
         ?string $expectedRequiredPhpVersion,
         bool $expectedHasRequiredPhpVersion,
         array $expectedRequiredExtensions,
-        ?string $expectedPolyfilledExtension,
+        array $expectedPolyfilledExtension,
     ): void {
         $packageInfo = new PackageInfo($rawPackageInfo);
 
@@ -57,7 +57,7 @@ final class PackageInfoTest extends TestCase
             null,
             false,
             [],
-            null,
+            [],
         ];
 
         yield 'has a PHP version required' => [
@@ -71,7 +71,7 @@ final class PackageInfoTest extends TestCase
             '^8.2',
             true,
             [],
-            null,
+            [],
         ];
 
         yield 'has a PHP version required as a dev dep' => [
@@ -85,7 +85,7 @@ final class PackageInfoTest extends TestCase
             null,
             false,
             [],
-            null,
+            [],
         ];
 
         yield 'has PHP extensions required' => [
@@ -108,22 +108,26 @@ final class PackageInfoTest extends TestCase
                 'phar',
                 'xdebug',
             ],
-            null,
+            [],
         ];
 
-        // TODO: need to add support
-        yield 'polyfills an extension' => [
+        yield 'polyfills extensions' => [
             [
                 'name' => 'box/test',
                 'provide' => [
-                    'mbstring' => '*',
+                    'ext-mbstring' => '*',
+                    'ext-ctype' => '*',
+                    'psr/log-implementation' => '1.0|2.0|3.0',
                 ],
             ],
             'box/test',
             null,
             false,
             [],
-            null,
+            [
+                'mbstring',
+                'ctype',
+            ],
         ];
 
         yield 'Symfony mbstring polyfill' => [
@@ -134,7 +138,7 @@ final class PackageInfoTest extends TestCase
             null,
             false,
             [],
-            'mbstring',
+            ['mbstring'],
         ];
 
         yield 'Symfony PHP polyfill' => [
@@ -145,7 +149,7 @@ final class PackageInfoTest extends TestCase
             null,
             false,
             [],
-            null,
+            [],
         ];
 
         yield 'phpseclib/mcrypt_compat' => [
@@ -156,7 +160,7 @@ final class PackageInfoTest extends TestCase
             null,
             false,
             [],
-            'mcrypt',
+            ['mcrypt'],
         ];
 
         yield 'nominal' => [
@@ -258,7 +262,7 @@ final class PackageInfoTest extends TestCase
             '>=7.1',
             true,
             [],
-            null,
+            [],
         ];
     }
 
@@ -268,12 +272,12 @@ final class PackageInfoTest extends TestCase
         ?string $expectedRequiredPhpVersion,
         bool $expectedHasRequiredPhpVersion,
         array $expectedRequiredExtensions,
-        ?string $expectedPolyfilledExtension,
+        array $expectedPolyfilledExtension,
     ): void {
         self::assertSame($expectedName, $actual->getName());
         self::assertSame($expectedRequiredPhpVersion, $actual->getRequiredPhpVersion());
         self::assertSame($expectedHasRequiredPhpVersion, $actual->hasRequiredPhpVersion());
         self::assertSame($expectedRequiredExtensions, $actual->getRequiredExtensions());
-        self::assertSame($expectedPolyfilledExtension, $actual->getPolyfilledExtension());
+        self::assertSame($expectedPolyfilledExtension, $actual->getPolyfilledExtensions());
     }
 }


### PR DESCRIPTION
When we have access to a package info in a `composer.lock`, which extension a package may polyfill can be found in the `provide` section. This is much more reliable than trying to guess it from some package conventions like the Symfony polyfills or manually map some other popular polyfills.

The previous way of doing it kept for now, in case we fall back to the `composer.json`, but it will disappear as soon as we no longer support inferring the requirements from the `composer.json` file in 5.0.