### PR TITLE
fix(requirement-checker): Fix the constraint message displayed

### DIFF
--- a/requirement-checker/fixtures/fail-complete/expected-boxmin-stderr.dist
+++ b/requirement-checker/fixtures/fail-complete/expected-boxmin-stderr.dist
@@ -8,8 +8,10 @@ Box Requirements Checker
 
 > Checking Box requirements:
   ✘ The application requires a version matching "^10".
-  ✔ The application requires the extension "phar".
-  ✔ The package "package-with-extensions" requires the extension "json".
+  ✔ The application requires the extension "phar". Enable it or install a
+polyfill.
+  ✔ The package "package-with-extensions" requires the extension "json". Enable
+it or install a polyfill.
   ✘ The package "package-with-extensions" requires the extension "ldap". Enable
 it or install a polyfill.
   ✘ The package "package-with-extensions" requires the extension "random".
@@ -23,8 +25,6 @@ Fix the following mandatory requirements:
 =========================================
 
  * The application requires a version matching "^10".
- * The package "package-with-extensions" requires the extension "ldap". Enable
-   it or install a polyfill.
- * The package "package-with-extensions" requires the extension "random". Enable
-   it or install a polyfill.
+ * The package "package-with-extensions" requires the extension "ldap".
+ * The package "package-with-extensions" requires the extension "random".
 

--- a/requirement-checker/fixtures/fail-complete/expected-composermin-stderr.dist
+++ b/requirement-checker/fixtures/fail-complete/expected-composermin-stderr.dist
@@ -8,8 +8,10 @@ Box Requirements Checker
 
 > Checking Box requirements:
   ✘ The application requires a version matching "^10".
-  ✔ The application requires the extension "phar".
-  ✔ The package "package-with-extensions" requires the extension "json".
+  ✔ The application requires the extension "phar". Enable it or install a
+polyfill.
+  ✔ The package "package-with-extensions" requires the extension "json". Enable
+it or install a polyfill.
   ✘ The package "package-with-extensions" requires the extension "ldap". Enable
 it or install a polyfill.
   ✘ The package "package-with-extensions" requires the extension "random".
@@ -23,8 +25,6 @@ Fix the following mandatory requirements:
 =========================================
 
  * The application requires a version matching "^10".
- * The package "package-with-extensions" requires the extension "ldap". Enable
-   it or install a polyfill.
- * The package "package-with-extensions" requires the extension "random". Enable
-   it or install a polyfill.
+ * The package "package-with-extensions" requires the extension "ldap".
+ * The package "package-with-extensions" requires the extension "random".
 

--- a/requirement-checker/fixtures/fail-conflict/expected-boxmin-stderr.dist
+++ b/requirement-checker/fixtures/fail-conflict/expected-boxmin-stderr.dist
@@ -7,7 +7,8 @@ Box Requirements Checker
   WARNING: No configuration file (php.ini) used by PHP!
 
 > Checking Box requirements:
-  ✔ The application requires the extension "phar".
+  ✔ The application requires the extension "phar". Enable it or install a
+polyfill.
   ✘ The application conflicts with the extension "pdo".
 
                                                                                 
@@ -17,5 +18,5 @@ Box Requirements Checker
 Fix the following mandatory requirements:
 =========================================
 
- * The application conflicts with the extension "pdo".
+ * The application conflicts with the extension "pdo". Disable it.
 

--- a/requirement-checker/fixtures/pass-complete/expected-boxmin-stderr.dist
+++ b/requirement-checker/fixtures/pass-complete/expected-boxmin-stderr.dist
@@ -8,7 +8,8 @@ Box Requirements Checker
 
 > Checking Box requirements:
   ✔ The application requires a version matching ">=5.3".
-  ✔ The application requires the extension "phar".
+  ✔ The application requires the extension "phar". Enable it or install a
+polyfill.
   
                                                                                 
  [OK] Your system is ready to run the application.                              

--- a/requirement-checker/fixtures/pass-complete/expected-composermin-stderr.dist
+++ b/requirement-checker/fixtures/pass-complete/expected-composermin-stderr.dist
@@ -8,7 +8,8 @@ Box Requirements Checker
 
 > Checking Box requirements:
   ✔ The application requires a version matching ">=5.3".
-  ✔ The application requires the extension "phar".
+  ✔ The application requires the extension "phar". Enable it or install a
+polyfill.
   
                                                                                 
  [OK] Your system is ready to run the application.                              

--- a/requirement-checker/src/Checker.php
+++ b/requirement-checker/src/Checker.php
@@ -100,7 +100,7 @@ final class Checker
             }
 
             if (IO::VERBOSITY_DEBUG === $printer->getVerbosity()) {
-                $printer->printvln('✔ '.$requirement->getHelpText(), IO::VERBOSITY_DEBUG, 'green');
+                $printer->printvln('✔ '.$requirement->getTestMessage(), IO::VERBOSITY_DEBUG, 'green');
                 $printer->printv('  ', IO::VERBOSITY_DEBUG);
             } else {
                 $printer->printv('.', $verbosity, 'green');

--- a/requirement-checker/src/Printer.php
+++ b/requirement-checker/src/Printer.php
@@ -92,7 +92,7 @@ final class Printer
             return null;
         }
 
-        return wordwrap($requirement->getTestMessage(), $this->width - 3, PHP_EOL.'   ').PHP_EOL;
+        return wordwrap($requirement->getHelpText(), $this->width - 3, PHP_EOL.'   ').PHP_EOL;
     }
 
     public function block(string $title, string $message, int $verbosity, ?string $style = null): void

--- a/requirement-checker/tests/CheckerTest.php
+++ b/requirement-checker/tests/CheckerTest.php
@@ -63,8 +63,9 @@ class CheckerTest extends TestCase
     public function provideRequirements(): Generator
     {
         $phpVersion = PHP_VERSION;
+        $remainingVerbosities = ['verbosity=verbose' => IO::VERBOSITY_VERBOSE, 'verbosity=normal' => IO::VERBOSITY_NORMAL, 'verbosity=quiet' => IO::VERBOSITY_QUIET];
 
-        yield (static function () use ($phpVersion) {
+        yield 'no requirement; verbosity=debug' => (static function () use ($phpVersion) {
             return [
                 new RequirementCollection(),
                 IO::VERBOSITY_DEBUG,
@@ -89,7 +90,7 @@ class CheckerTest extends TestCase
             ];
         })();
 
-        yield (static function () use ($phpVersion) {
+        yield 'no requirement; verbosity=very verbose' => (static function () use ($phpVersion) {
             return [
                 new RequirementCollection(),
                 IO::VERBOSITY_VERY_VERBOSE,
@@ -114,8 +115,8 @@ class CheckerTest extends TestCase
             ];
         })();
 
-        foreach ([IO::VERBOSITY_VERBOSE, IO::VERBOSITY_NORMAL, IO::VERBOSITY_QUIET] as $verbosity) {
-            yield (static function () use ($verbosity) {
+        foreach ($remainingVerbosities as $label => $verbosity) {
+            yield 'no requirements; '.$label => (static function () use ($verbosity) {
                 return [
                     new RequirementCollection(),
                     $verbosity,
@@ -125,13 +126,13 @@ class CheckerTest extends TestCase
             })();
         }
 
-        yield (static function () use ($phpVersion) {
+        yield 'requirements; check passes; verbosity=debug' => (static function () use ($phpVersion) {
             $requirements = new RequirementCollection();
 
             $requirements->addRequirement(
                 new ConditionIsFulfilled(),
+                'The application requires the version "7.2.0" or greater.',
                 'The application requires the version "7.2.0" or greater. Got "7.2.2"',
-                'The application requires the version "7.2.0" or greater.'
             );
             $requirements->addRequirement(
                 new class() implements IsFulfilled {
@@ -140,8 +141,8 @@ class CheckerTest extends TestCase
                         return true;
                     }
                 },
+                'The package "acme/foo" requires the extension "random".',
                 'The package "acme/foo" requires the extension "random". Enable it or install a polyfill.',
-                'The package "acme/foo" requires the extension "random".'
             );
 
             return [
@@ -170,7 +171,7 @@ class CheckerTest extends TestCase
             ];
         })();
 
-        yield (static function () use ($phpVersion) {
+        yield 'requirements; check passes; verbosity=very verbose' => (static function () use ($phpVersion) {
             $requirements = new RequirementCollection();
 
             $requirements->addRequirement(
@@ -180,8 +181,8 @@ class CheckerTest extends TestCase
             );
             $requirements->addRequirement(
                 new ConditionIsFulfilled(),
+                'The package "acme/foo" requires the extension "random".',
                 'The package "acme/foo" requires the extension "random". Enable it or install a polyfill.',
-                'The package "acme/foo" requires the extension "random".'
             );
 
             return [
@@ -209,8 +210,8 @@ class CheckerTest extends TestCase
             ];
         })();
 
-        foreach ([IO::VERBOSITY_VERBOSE, IO::VERBOSITY_NORMAL, IO::VERBOSITY_QUIET] as $verbosity) {
-            yield (static function () use ($verbosity) {
+        foreach ($remainingVerbosities as $label => $verbosity) {
+            yield 'requirements; check passes; '.$label => (static function () use ($verbosity) {
                 $requirements = new RequirementCollection();
 
                 $requirements->addRequirement(
@@ -220,8 +221,8 @@ class CheckerTest extends TestCase
                 );
                 $requirements->addRequirement(
                     new ConditionIsFulfilled(),
+                    'The package "acme/foo" requires the extension "random".',
                     'The package "acme/foo" requires the extension "random". Enable it or install a polyfill.',
-                    'The package "acme/foo" requires the extension "random".'
                 );
 
                 return [
@@ -233,7 +234,7 @@ class CheckerTest extends TestCase
             })();
         }
 
-        yield (static function () use ($phpVersion) {
+        yield 'requirements; check do not pass; verbosity=debug' => (static function () use ($phpVersion) {
             $requirements = new RequirementCollection();
 
             $requirements->addRequirement(
@@ -243,8 +244,8 @@ class CheckerTest extends TestCase
             );
             $requirements->addRequirement(
                 new ConditionIsNotFulfilled(),
+                'The package "acme/foo" requires the extension "random".',
                 'The package "acme/foo" requires the extension "random". Enable it or install a polyfill.',
-                'The package "acme/foo" requires the extension "random".'
             );
 
             return [
@@ -261,9 +262,8 @@ class CheckerTest extends TestCase
                       /path/to/php.ini
 
                     > Checking Box requirements:
-                      ✔ The application requires the version "7.2.0" or greater.
-                      ✘ The package "acme/foo" requires the extension "random". Enable it or install
-                    a polyfill.
+                      ✔ The application requires the version "7.2.0" or greater. Got "7.2.2"
+                      ✘ The package "acme/foo" requires the extension "random".
 
 
                      [ERROR] Your system is not ready to run the application.
@@ -280,8 +280,8 @@ class CheckerTest extends TestCase
             ];
         })();
 
-        foreach ([IO::VERBOSITY_VERY_VERBOSE, IO::VERBOSITY_VERBOSE, IO::VERBOSITY_NORMAL] as $verbosity) {
-            yield (static function () use ($verbosity, $phpVersion) {
+        foreach (['verbosity=very verbose' => IO::VERBOSITY_VERY_VERBOSE, 'verbosity=verbose' => IO::VERBOSITY_VERBOSE, 'verbosity=normal' => IO::VERBOSITY_NORMAL] as $label => $verbosity) {
+            yield 'requirements; check do not pass; '.$label => (static function () use ($verbosity, $phpVersion) {
                 $requirements = new RequirementCollection();
 
                 $requirements->addRequirement(
@@ -291,8 +291,8 @@ class CheckerTest extends TestCase
                 );
                 $requirements->addRequirement(
                     new ConditionIsNotFulfilled(),
+                    'The package "acme/foo" requires the extension "random".',
                     'The package "acme/foo" requires the extension "random". Enable it or install a polyfill.',
-                    'The package "acme/foo" requires the extension "random".'
                 );
 
                 return [
@@ -327,7 +327,7 @@ class CheckerTest extends TestCase
             })();
         }
 
-        yield (static function () use ($phpVersion) {
+        yield 'requirements; check do not pass; verbosity=quiet' => (static function () use ($phpVersion) {
             $requirements = new RequirementCollection();
 
             $requirements->addRequirement(
@@ -337,8 +337,8 @@ class CheckerTest extends TestCase
             );
             $requirements->addRequirement(
                 new ConditionIsNotFulfilled(),
+                'The package "acme/foo" requires the extension "random".',
                 'The package "acme/foo" requires the extension "random". Enable it or install a polyfill.',
-                'The package "acme/foo" requires the extension "random".'
             );
 
             return [

--- a/requirement-checker/tests/PrinterTest.php
+++ b/requirement-checker/tests/PrinterTest.php
@@ -195,7 +195,7 @@ class PrinterTest extends TestCase
             false,
             50,
             <<<'EOF'
-                Test message
+                Help message
 
                 EOF
         ];
@@ -210,7 +210,7 @@ class PrinterTest extends TestCase
             true,
             50,
             <<<'EOF'
-                Test message
+                Help message
 
                 EOF
         ];

--- a/res/requirement-checker/src/Checker.php
+++ b/res/requirement-checker/src/Checker.php
@@ -54,7 +54,7 @@ final class Checker
                 continue;
             }
             if (IO::VERBOSITY_DEBUG === $printer->getVerbosity()) {
-                $printer->printvln('✔ ' . $requirement->getHelpText(), IO::VERBOSITY_DEBUG, 'green');
+                $printer->printvln('✔ ' . $requirement->getTestMessage(), IO::VERBOSITY_DEBUG, 'green');
                 $printer->printv('  ', IO::VERBOSITY_DEBUG);
             } else {
                 $printer->printv('.', $verbosity, 'green');

--- a/res/requirement-checker/src/Printer.php
+++ b/res/requirement-checker/src/Printer.php
@@ -54,7 +54,7 @@ final class Printer
         if ($requirement->isFulfilled()) {
             return null;
         }
-        return wordwrap($requirement->getTestMessage(), $this->width - 3, PHP_EOL . '   ') . PHP_EOL;
+        return wordwrap($requirement->getHelpText(), $this->width - 3, PHP_EOL . '   ') . PHP_EOL;
     }
     public function block(string $title, string $message, int $verbosity, ?string $style = null) : void
     {


### PR DESCRIPTION
- When printing the constraint checked, the message shown should be the requirement message.
- When priting the recommendations, the message shown should be the failed requirements *help* message.

The current final output now makes no sense (it is inversed), but this is because the messages set upstream are incorrect and they will be fixed separately.