### PR TITLE
ci: fix the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
                     name: box-phar
                     path: .
 
-            -   name: Upload box.phar
+            -   name: Upload PHAR to the release
                 uses: softprops/action-gh-release@v1
                 with:
                     token: ${{ secrets.GITHUB_TOKEN }}
@@ -91,16 +91,27 @@ jobs:
                         box.phar
                         box.phar.asc
 
+
+    publish-homebrew-tap:
+        runs-on: ubuntu-latest
+        name: Publish Homebrew tap
+        needs:
+            - publish-phar
+        if: github.event_name == 'release'
+        steps:
             -   name: Update Homebrew formula
                 uses: dawidd6/action-homebrew-bump-formula@v3
                 with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
+                    token: ${{ secrets.BOX_HOMEBREW_TAP_TOKEN }}
                     tap: box-project/homebrew-box
                     formula: humbug/box
+                    tag: ${{ github.event.release.tag_name }}
+                    revision: ${{ github.event.release.target_commitish }}
+
 
     publish-docker-image:
         runs-on: ubuntu-latest
-        name: Publish PHAR
+        name: Publish the Docker image
         needs:
             - build-phar
         if: github.event_name == 'release'
@@ -113,10 +124,10 @@ jobs:
             # See https://github.com/actions/download-artifact#limitations
             # the permissions are not guaranteed to be preserved
             -   name: Ensure PHAR is executable
-                run: chmod 755 bin/box.phar
+                run: chmod 755 box.phar
 
             -   name: Check that the PHAR works
-                run: bin/box.phar --ansi --version
+                run: box.phar --ansi --version
 
             -   name: Set up QEMU
                 uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
- Publish the homebrew formula in a different dedicated step
- Use a dedicated access token for updating the homebrew formula
- Fix the name of Docker publish job
- Fix the access to the PHAR within the Docker publish job