### PR TITLE
Add new `manifest` option for configuration

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,6 +29,7 @@
     1. [Signing algorithm (`algorithm`)][algorithm]
     1. [The private key (`key`)][key]
     1. [The private key password (`key-pass`)][key-pass]
+1. [Manifest (`manifest`)][manifest]
 1. [Metadata (`metadata`)][metadata]
 1. [Replaceable placeholders][placeholders]
     1. [Replacements (`replacements`)][replacements]
@@ -85,6 +86,7 @@ to `null`, then its default value will be picked and is strictly equivalent to n
     "key": "?",
     "key-pass": "?",
     "main": "?",
+    "manifest": "?",
     "map": "?",
     "metadata": "?",
     "output": "?",
@@ -784,6 +786,28 @@ prompted for the passphrase unless you are not in an interactive environment.
 This setting will be ignored if no [key][key] has been provided.
 
 
+## Manifest (`manifest`)
+
+The manifest (`string`|`null` default `null`) setting is used to specify the filename included with the phar file list
+that must contains the software components and dependencies list.
+
+If you specify `auto`, it will search in order for following files until once was found to be used as a manifest: 
+`manifest.txt`, `manifest.xml`, `sbom.xml`, `sbom.json`
+
+In case you are many files in different format, and want to be sure to use a specific version, then you will have to set
+the `manifest` setting.
+
+With the configuration excerpt:
+
+```json
+{
+    "manifest": "sbom.json"
+}
+```
+
+For example, if I've both `sbom.xml` and `sbom.json` files available, and I want to use the json version.
+
+
 ## Metadata (`metadata`)
 
 The metadata (`any` default none) setting can be any value. This value will be stored as metadata that can be retrieved
@@ -1010,6 +1034,7 @@ The short commit hash will only be used if no tag is available.
 [key-pass]: #the-private-key-password-key-pass
 [key]: #the-private-key-key
 [main]: #main-main
+[manifest]: #manifest-manifest
 [map]: #map-map
 [metadata]: #metadata-metadata
 [output]: #output-output

--- a/res/schema.json
+++ b/res/schema.json
@@ -173,6 +173,9 @@
             "description": "The file path to the main script.",
             "type": ["boolean", "string", "null"]
         },
+        "manifest": {
+            "description": "Add a manifest on phar contents."
+        },
         "map": {
             "description": "The mapping of file system paths to phar paths.",
             "type": ["array", "null"],

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -209,6 +209,7 @@ final class Configuration
     private const KEY_PASS_KEY = 'key-pass';
     private const MAIN_KEY = 'main';
     private const MAP_KEY = 'map';
+    private const MANIFEST_KEY = 'manifest';
     private const METADATA_KEY = 'metadata';
     private const OUTPUT_KEY = 'output';
     private const PHP_SCOPER_KEY = 'php-scoper';
@@ -340,6 +341,8 @@ final class Configuration
         $map = self::retrieveMap($raw, $logger);
         $fileMapper = new MapFile($basePath, $map);
 
+        $manifest = self::retrieveManifest($raw, $logger);
+
         $metadata = self::retrieveMetadata($raw, $logger);
 
         $signingAlgorithm = self::retrieveSigningAlgorithm($raw, $logger);
@@ -384,6 +387,7 @@ final class Configuration
             $checkRequirements,
             $logger->getWarnings(),
             $logger->getRecommendations(),
+            $manifest,
         );
     }
 
@@ -456,6 +460,7 @@ final class Configuration
         private bool $checkRequirements,
         private array $warnings,
         private array $recommendations,
+        private mixed $manifest,
     ) {
         if (null === $mainScriptPath) {
             Assert::null($mainScriptContents);
@@ -698,6 +703,11 @@ final class Configuration
     public function getRecommendations(): array
     {
         return $this->recommendations;
+    }
+
+    public function getManifest(): ?string
+    {
+        return $this->manifest;
     }
 
     private static function retrieveAlias(stdClass $raw, bool $userStubUsed, ConfigurationLogger $logger): string
@@ -1876,6 +1886,17 @@ final class Configuration
         }
 
         return $map;
+    }
+
+    private static function retrieveManifest(stdClass $raw, ConfigurationLogger $logger)
+    {
+        self::checkIfDefaultValue($logger, $raw, self::MANIFEST_KEY);
+
+        if (false === isset($raw->{self::MANIFEST_KEY})) {
+            return null;
+        }
+
+        return $raw->{self::MANIFEST_KEY};
     }
 
     private static function retrieveMetadata(stdClass $raw, ConfigurationLogger $logger)

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -867,11 +867,6 @@ final class Compile implements CommandAware
                     $manifest,
                 ),
             );
-        } else {
-            $logger->log(
-                CompilerLogger::MINUS_PREFIX,
-                'No manifest',
-            );
         }
 
         return StubGenerator::generateStub(

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -818,6 +818,7 @@ final class Compile implements CommandAware
         $shebang = $config->getShebang();
         $bannerPath = $config->getStubBannerPath();
         $bannerContents = $config->getStubBannerContents();
+        $manifest = $config->getManifest();
 
         if (null !== $shebang) {
             $logger->log(
@@ -858,6 +859,21 @@ final class Compile implements CommandAware
             }
         }
 
+        if (null !== $manifest) {
+            $logger->log(
+                CompilerLogger::MINUS_PREFIX,
+                sprintf(
+                    'Using manifest: %s',
+                    $manifest,
+                ),
+            );
+        } else {
+            $logger->log(
+                CompilerLogger::MINUS_PREFIX,
+                'No manifest',
+            );
+        }
+
         return StubGenerator::generateStub(
             $config->getAlias(),
             $bannerContents,
@@ -865,6 +881,7 @@ final class Compile implements CommandAware
             $config->isInterceptFileFuncs(),
             $shebang,
             $checkRequirements,
+            $manifest
         );
     }
 

--- a/src/StubGenerator.php
+++ b/src/StubGenerator.php
@@ -37,9 +37,7 @@ final class StubGenerator
         __BOX_BANNER__
 
         __BOX_PHAR_CONFIG__
-
         __BOX_PHAR_MANIFEST__
-
         __HALT_COMPILER(); ?>
 
         STUB;
@@ -86,7 +84,7 @@ final class StubGenerator
         );
 
         return str_replace(
-            "__BOX_PHAR_MANIFEST__\n",
+            "__BOX_PHAR_MANIFEST__",
             self::generateManifestStmt($alias, $manifest),
             $stub,
         );
@@ -202,6 +200,10 @@ final class StubGenerator
                 $stub[] = '}';
                 break;
             }
+        }
+
+        if ([] === $stub) {
+            return "";
         }
 
         return implode("\n", $stub)."\n";

--- a/src/StubGenerator.php
+++ b/src/StubGenerator.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use function addcslashes;
+use function file_exists;
 use function implode;
 use function realpath;
 use function str_replace;
@@ -187,18 +188,18 @@ final class StubGenerator
         $resources = 'auto' === $manifest ? ['manifest.txt', 'manifest.xml', 'sbom.xml', 'sbom.json'] : ($manifest ? [$manifest] : []);
 
         foreach ($resources as $resource) {
-            $resolved = realpath($resource) ?: (\file_exists($resource) ? $resource : null);
+            $resolved = realpath($resource) ?: (file_exists($resource) ? $resource : null);
             if ($resolved) {
                 $stub[] = '$io = \Fidry\Console\Input\IO::createDefault();';
                 $stub[] = 'if (true === $io->getInput()->hasParameterOption(["--manifest"], true)) {';
                 $stub[] = null === $alias
                     ? '    $phar = new \Phar(" . __FILE__ . ");'
-                    : '    $phar = new \Phar("' . $alias . '");';
+                    : '    $phar = new \Phar("'.$alias.'");';
                 $stub[] = null === $alias
-                    ? '    $io->writeln(\file_get_contents("phar://" . __FILE__ . "/'. $resource . '"));'
-                    : '    $io->writeln(\file_get_contents("phar://' . $alias . '/'. $resource . '"));';
-                $stub[] = "    exit(\\Fidry\\Console\\ExitCode::SUCCESS);";
-                $stub[] = "}";
+                    ? '    $io->writeln(\file_get_contents("phar://" . __FILE__ . "/'.$resource.'"));'
+                    : '    $io->writeln(\file_get_contents("phar://'.$alias.'/'.$resource.'"));';
+                $stub[] = '    exit(\\Fidry\\Console\\ExitCode::SUCCESS);';
+                $stub[] = '}';
                 break;
             }
         }

--- a/src/StubGenerator.php
+++ b/src/StubGenerator.php
@@ -84,7 +84,7 @@ final class StubGenerator
         );
 
         return str_replace(
-            "__BOX_PHAR_MANIFEST__",
+            '__BOX_PHAR_MANIFEST__',
             self::generateManifestStmt($alias, $manifest),
             $stub,
         );
@@ -203,7 +203,7 @@ final class StubGenerator
         }
 
         if ([] === $stub) {
-            return "";
+            return '';
         }
 
         return implode("\n", $stub)."\n";

--- a/tests/StubGeneratorTest.php
+++ b/tests/StubGeneratorTest.php
@@ -36,6 +36,7 @@ class StubGeneratorTest extends TestCase
         bool $intercept,
         ?string $shebang,
         bool $checkRequirements,
+        ?string $manifest,
         string $expected,
     ): void {
         $actual = StubGenerator::generateStub(
@@ -45,6 +46,7 @@ class StubGeneratorTest extends TestCase
             $intercept,
             $shebang,
             $checkRequirements,
+            $manifest,
         );
 
         self::assertSame($expected, $actual);


### PR DESCRIPTION
Hello

Accorrding to my recent work on [`bartlett/box-manifest`](https://github.com/llaville/box-manifest/tree/3.x) v3.0 (that will soon been available), and the thread opened by feature report #841, I would like here by this PR : 

- suggest to add a new `manifest` option that will allow to add at compile time the chunk of code required to display content of a manifest later when invoking your PHAR distrib with command : `my-phar.phar --manifest`.

All manifest formats supported by `box-manifest` project are :  
- SBOM JSON or XML format following specification 1.1, 1.2, 1.3, or 1.4 
- Simple key-value pairs TEXT format without decoration
- key-value pairs TEXT format with ansi decoration

Programmatically script (phar-manifest.php) and results are available at https://github.com/llaville/box-manifest/tree/3.x/examples
 