### PR TITLE
ci: Ensure the requirement checker references are not changing

### DIFF
--- a/.github/workflows/requirement-checker.yaml
+++ b/.github/workflows/requirement-checker.yaml
@@ -293,6 +293,8 @@ jobs:
                     working-directory: requirement-checker
                     dependency-versions: ${{ matrix.php.dependency }}
                     composer-options: ${{ matrix.php.composer-options }}
+                env:
+                    COMPOSER_ROOT_VERSION: "4.x.x-dev"
 
             -   name: Ensure that the make target is up to date
                 run: cd requirement-checker; make _vendor_install
@@ -302,6 +304,8 @@ jobs:
                 with:
                     dependency-versions: ${{ matrix.php.dependency }}
                     composer-options: ${{ matrix.php.composer-options }}
+                env:
+                    COMPOSER_ROOT_VERSION: "4.x.x-dev"
 
             -   name: Ensure that the make target is up to date
                 run: make _vendor_install


### PR DESCRIPTION
Due to the git reference changing all the time, we always get a change for the requirement checker resulting in a PR being made.