### PR TITLE
Requirement checker fails in Git Bash

### DIFF
--- a/requirement-checker/src/Terminal.php
+++ b/requirement-checker/src/Terminal.php
@@ -96,7 +96,8 @@ class Terminal
     private static function initDimensions(): void
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
-            if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON')), $matches)) {
+            $ansicon = getenv('ANSICON');
+            if (false !== $ansicon && preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim($ansicon), $matches)) {
                 // extract [w, H] from "wxh (WxH)"
                 // or [w, h] from "wxh"
                 self::$width = (int) $matches[1];

--- a/res/requirement-checker/src/Terminal.php
+++ b/res/requirement-checker/src/Terminal.php
@@ -57,7 +57,8 @@ class Terminal
     private static function initDimensions() : void
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
-            if (preg_match('/^(\\d+)x(\\d+)(?: \\((\\d+)x(\\d+)\\))?$/', trim(getenv('ANSICON')), $matches)) {
+            $ansicon = getenv('ANSICON');
+            if (\false !== $ansicon && preg_match('/^(\\d+)x(\\d+)(?: \\((\\d+)x(\\d+)\\))?$/', trim($ansicon), $matches)) {
                 self::$width = (int) $matches[1];
                 self::$height = isset($matches[4]) ? (int) $matches[4] : (int) $matches[2];
             } elseif (!self::hasVt100Support() && self::hasSttyAvailable()) {


### PR DESCRIPTION
If you attempt to run a compiled project in Git Bash (Windows 11), you'll get an error from the requirements checker:
> trim(): Argument #1 ($string) must be of type string, bool given in acli.phar/.box/src/Terminal.php:60

I understand this code is copied from Symfony Console, which means this bug likely exists upstream as well: https://github.com/symfony/symfony/pull/50143