### PR TITLE
Fix TypeError in Terminal.php if getenv() returns false

### DIFF
--- a/requirement-checker/src/Terminal.php
+++ b/requirement-checker/src/Terminal.php
@@ -96,7 +96,7 @@ class Terminal
     private static function initDimensions(): void
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
-            if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON')), $matches)) {
+            if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON') ?: ''), $matches)) {
                 // extract [w, H] from "wxh (WxH)"
                 // or [w, h] from "wxh"
                 self::$width = (int) $matches[1];

--- a/res/requirement-checker/src/Terminal.php
+++ b/res/requirement-checker/src/Terminal.php
@@ -57,7 +57,7 @@ class Terminal
     private static function initDimensions() : void
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
-            if (preg_match('/^(\\d+)x(\\d+)(?: \\((\\d+)x(\\d+)\\))?$/', trim(getenv('ANSICON')), $matches)) {
+            if (preg_match('/^(\\d+)x(\\d+)(?: \\((\\d+)x(\\d+)\\))?$/', trim(getenv('ANSICON') ?: ''), $matches)) {
                 self::$width = (int) $matches[1];
                 self::$height = isset($matches[4]) ? (int) $matches[4] : (int) $matches[2];
             } elseif (!self::hasVt100Support() && self::hasSttyAvailable()) {


### PR DESCRIPTION
This PR fixes the following error:

```
Fatal error: Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, bool given
in phar://.../box.phar/.box/src/Terminal.php:60
```
