### PR TITLE
fix: resolve strict types `trim()` issue on Windows

### DIFF
--- a/requirement-checker/src/Terminal.php
+++ b/requirement-checker/src/Terminal.php
@@ -96,7 +96,7 @@ class Terminal
     private static function initDimensions(): void
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
-            if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON')), $matches)) {
+            if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON') ?: ''), $matches)) {
                 // extract [w, H] from "wxh (WxH)"
                 // or [w, h] from "wxh"
                 self::$width = (int) $matches[1];


### PR DESCRIPTION
This resolves an issue where `getenv('ANSICON')` returns `false` if the env variable is not set, which causes issues on Windows with `trim()` due to strict types.

Closes #1002