### PR TITLE
ci: Add a concurrency strategy

### DIFF
--- a/.github/workflows/auto-review.yaml
+++ b/.github/workflows/auto-review.yaml
@@ -8,6 +8,11 @@ on:
         # Do not make it the first of the month and/or midnight since it is a very busy time
         - cron: "* 10 5 * *"
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     lint-cs:
         runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,6 +10,11 @@ on:
     release:
         types: [ created ]
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
     packages: write

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -10,6 +10,11 @@ on:
     release:
         types: [ created ]
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 env:
     POLLING_INTERVALS_SEC: 30
     SLEEP_TIME_SEC: 60s

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -9,6 +9,11 @@ on:
             - mkdocs.yaml
             - .github/workflows/gh-pages.yaml
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     deploy:
         runs-on: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,11 @@ on:
     release:
         types: [ created ]
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 env:
     DOCKERFILE: .docker/Dockerfile
     DOCKERHUB_USERNAME: boxproject

--- a/.github/workflows/requirement-checker.yaml
+++ b/.github/workflows/requirement-checker.yaml
@@ -8,6 +8,11 @@ on:
         # Do not make it the first of the month and/or midnight since it is a very busy time
         - cron: "* 10 5 * *"
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 env:
     POLLING_INTERVALS_SEC: 30
     SLEEP_TIME_SEC: 60s

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,11 @@ on:
     release:
         types: [ created ]
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     security:
         runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,6 +10,11 @@ on:
     release:
         types: [ created ]
 
+# See https://stackoverflow.com/a/72408109
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     unit-tests:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Currently when merging a couple of PRs the CI is having a meltdown. This is an attempt to reduce the load.