### PR TITLE
refactor: Rename SafePhar into PharInfo

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -23,7 +23,6 @@ use KevinGH\Box\Compactor\Compactors;
 use KevinGH\Box\Compactor\PhpScoper;
 use KevinGH\Box\Compactor\Placeholder;
 use KevinGH\Box\Phar\CompressionAlgorithm;
-use KevinGH\Box\Phar\SafePhar;
 use KevinGH\Box\PhpScoper\NullScoper;
 use KevinGH\Box\PhpScoper\Scoper;
 use Phar;
@@ -93,14 +92,6 @@ final class Box implements Countable
         return new self(
             new Phar($pharFilePath, $pharFlags, $pharAlias),
             $pharFilePath,
-        );
-    }
-
-    public static function createFromPharaoh(SafePhar $pharaoh): self
-    {
-        return new self(
-            $pharaoh->getPhar(),
-            $pharaoh->getFile(),
         );
     }
 

--- a/src/Console/Command/Diff.php
+++ b/src/Console/Command/Diff.php
@@ -20,8 +20,8 @@ use Fidry\Console\ExitCode;
 use Fidry\Console\Input\IO;
 use KevinGH\Box\Console\PharInfoRenderer;
 use KevinGH\Box\Phar\CompressionAlgorithm;
-use KevinGH\Box\Phar\SafePhar;
-use KevinGH\Box\PharInfo\PharDiff;
+use KevinGH\Box\Phar\PharDiff;
+use KevinGH\Box\Phar\PharInfo;
 use PharFileInfo;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -228,7 +228,7 @@ final class Diff implements Command
     /**
      * @param list<non-empty-string> $paths
      */
-    private static function renderPaths(string $symbol, SafePhar $pharInfo, array $paths, IO $io): void
+    private static function renderPaths(string $symbol, PharInfo $pharInfo, array $paths, IO $io): void
     {
         foreach ($paths as $path) {
             /** @var PharFileInfo $file */
@@ -259,7 +259,7 @@ final class Diff implements Command
         }
     }
 
-    private static function renderArchive(string $fileName, SafePhar $pharInfo, IO $io): void
+    private static function renderArchive(string $fileName, PharInfo $pharInfo, IO $io): void
     {
         $io->writeln(
             sprintf(

--- a/src/Console/Command/Info.php
+++ b/src/Console/Command/Info.php
@@ -19,7 +19,7 @@ use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Input\IO;
 use KevinGH\Box\Console\PharInfoRenderer;
-use KevinGH\Box\Phar\SafePhar;
+use KevinGH\Box\Phar\PharInfo;
 use Phar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -130,7 +130,7 @@ final class Info implements Command
         $mode = $io->getOption(self::MODE_OPT)->asStringChoice(self::MODES);
 
         try {
-            $pharInfo = new SafePhar($file);
+            $pharInfo = new PharInfo($file);
 
             return self::showPharInfo(
                 $pharInfo,
@@ -188,7 +188,7 @@ final class Info implements Command
     }
 
     private static function showPharInfo(
-        SafePhar $pharInfo,
+        PharInfo $pharInfo,
         bool $content,
         int|false $maxDepth,
         bool $indent,
@@ -210,7 +210,7 @@ final class Info implements Command
         return ExitCode::SUCCESS;
     }
 
-    private static function showPharMeta(SafePhar $pharInfo, IO $io): void
+    private static function showPharMeta(PharInfo $pharInfo, IO $io): void
     {
         $io->writeln(
             sprintf(

--- a/src/Console/Command/Verify.php
+++ b/src/Console/Command/Verify.php
@@ -18,7 +18,7 @@ use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Input\IO;
-use KevinGH\Box\Phar\SafePhar;
+use KevinGH\Box\Phar\PharInfo;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Filesystem\Path;
 use Throwable;
@@ -117,10 +117,10 @@ final class Verify implements Command
         $throwable = null;
 
         try {
-            $phar = new SafePhar($pharFilePath);
+            $pharInfo = new PharInfo($pharFilePath);
 
             $verified = true;
-            $signature = $phar->getSignature();
+            $signature = $pharInfo->getSignature();
         } catch (Throwable $throwable) {
             // Continue
         }

--- a/src/Console/PharInfoRenderer.php
+++ b/src/Console/PharInfoRenderer.php
@@ -17,7 +17,7 @@ namespace KevinGH\Box\Console;
 use Fidry\Console\Input\IO;
 use KevinGH\Box\NotInstantiable;
 use KevinGH\Box\Phar\CompressionAlgorithm;
-use KevinGH\Box\Phar\SafePhar;
+use KevinGH\Box\Phar\PharInfo;
 use SplFileInfo;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
@@ -43,7 +43,7 @@ final class PharInfoRenderer
 
     private const INDENT_SIZE = 2;
 
-    public static function renderCompression(SafePhar $pharInfo, IO $io): void
+    public static function renderCompression(PharInfo $pharInfo, IO $io): void
     {
         $io->writeln(
             sprintf(
@@ -94,7 +94,7 @@ final class PharInfoRenderer
         }
     }
 
-    public static function renderSignature(SafePhar $pharInfo, IO $io): void
+    public static function renderSignature(PharInfo $pharInfo, IO $io): void
     {
         $signature = $pharInfo->getSignature();
 
@@ -118,7 +118,7 @@ final class PharInfoRenderer
         );
     }
 
-    public static function renderMetadata(SafePhar $pharInfo, IO $io): void
+    public static function renderMetadata(PharInfo $pharInfo, IO $io): void
     {
         $metadata = $pharInfo->getNormalizedMetadata();
 
@@ -130,7 +130,7 @@ final class PharInfoRenderer
         }
     }
 
-    public static function renderContentsSummary(SafePhar $pharInfo, IO $io): void
+    public static function renderContentsSummary(PharInfo $pharInfo, IO $io): void
     {
         $count = array_filter($pharInfo->getFilesCompressionCount());
         $totalCount = array_sum($count);
@@ -152,7 +152,7 @@ final class PharInfoRenderer
      */
     public static function renderContent(
         OutputInterface $output,
-        SafePhar $pharInfo,
+        PharInfo $pharInfo,
         int|false $maxDepth,
         bool $indent,
     ): void {

--- a/src/Phar/PharDiff.php
+++ b/src/Phar/PharDiff.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\PharInfo;
 
-use KevinGH\Box\Phar\SafePhar;
+use KevinGH\Box\Phar\PharInfo;
 use KevinGH\Box\Pharaoh\PharDiff as ParagoniePharDiff;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
@@ -29,13 +29,13 @@ use const DIRECTORY_SEPARATOR;
 final class PharDiff
 {
     private readonly ParagoniePharDiff $diff;
-    private readonly SafePhar $pharA;
-    private readonly SafePhar $pharB;
+    private readonly PharInfo $pharA;
+    private readonly PharInfo $pharB;
 
     public function __construct(string $pathA, string $pathB)
     {
         $phars = array_map(
-            static fn (string $path) => new SafePhar($path),
+            static fn (string $path) => new PharInfo($path),
             [$pathA, $pathB],
         );
 
@@ -48,12 +48,12 @@ final class PharDiff
         $this->diff = $diff;
     }
 
-    public function getPharA(): SafePhar
+    public function getPharA(): PharInfo
     {
         return $this->pharA;
     }
 
-    public function getPharB(): SafePhar
+    public function getPharB(): PharInfo
     {
         return $this->pharB;
     }
@@ -100,20 +100,20 @@ final class PharDiff
         ];
     }
 
-    private static function getDiff(SafePhar $pharA, SafePhar $pharB, string $command): ?string
+    private static function getDiff(PharInfo $pharInfoA, PharInfo $pharInfoB, string $command): ?string
     {
-        $pharATmp = $pharA->getTmp();
-        $pharBTmp = $pharB->getTmp();
+        $pharInfoATmp = $pharInfoA->getTmp();
+        $pharInfoBTmp = $pharInfoB->getTmp();
 
-        $pharAFileName = $pharA->getFileName();
-        $pharBFileName = $pharB->getFileName();
+        $pharInfoAFileName = $pharInfoA->getFileName();
+        $pharInfoBFileName = $pharInfoB->getFileName();
 
         $diffCommmand = implode(
             ' ',
             [
                 $command,
-                $pharATmp,
-                $pharBTmp,
+                $pharInfoATmp,
+                $pharInfoBTmp,
             ],
         );
 
@@ -131,12 +131,12 @@ final class PharDiff
 
         return str_replace(
             [
-                $pharATmp,
-                $pharBTmp,
+                $pharInfoATmp,
+                $pharInfoBTmp,
             ],
             [
-                $pharAFileName,
-                $pharBFileName,
+                $pharInfoAFileName,
+                $pharInfoBFileName,
             ],
             $diff,
         );
@@ -145,7 +145,7 @@ final class PharDiff
     /**
      * @return string[]
      */
-    private static function collectFiles(SafePhar $phar): array
+    private static function collectFiles(PharInfo $phar): array
     {
         $basePath = $phar->getTmp().DIRECTORY_SEPARATOR;
 

--- a/src/Phar/PharInfo.php
+++ b/src/Phar/PharInfo.php
@@ -66,14 +66,14 @@ use function sprintf;
 /**
  * @private
  *
- * SafePhar is a wrapper around the native Phar class. Its goal is to provide an equivalent API whilst being in-memory
+ * PharInfo is a wrapper around the native Phar class. Its goal is to provide an equivalent API whilst being in-memory
  * safe.
  *
  * Indeed, the native Phar API is extremely limited due to the fact that it loads the code in-memory. This pollutes the
- * current process and will result in a crash if another PHAR with the same alias is loaded. This SafePhar class
+ * current process and will result in a crash if another PHAR with the same alias is loaded. This PharInfo class
  * circumvents those issues by extracting all the desired information in a separate process.
  */
-final class SafePhar
+final class PharInfo
 {
     private static array $ALGORITHMS;
     private static string $stubfile;

--- a/tests/Phar/PharInfoTest.php
+++ b/tests/Phar/PharInfoTest.php
@@ -22,12 +22,12 @@ use function Safe\file_get_contents;
 use function Safe\realpath;
 
 /**
- * @covers \KevinGH\Box\Phar\SafePhar
+ * @covers \KevinGH\Box\Phar\PharInfo
  * @runTestsInSeparateProcesses
  *
  * @internal
  */
-final class SafePharTest extends TestCase
+final class PharInfoTest extends TestCase
 {
     private const FIXTURES_DIR = __DIR__.'/../../fixtures';
 
@@ -43,7 +43,7 @@ final class SafePharTest extends TestCase
         ?string $expectedStub,
         array $expectedFileRelativePaths,
     ): void {
-        $pharInfo = new SafePhar($file);
+        $pharInfo = new PharInfo($file);
 
         self::assertSame(realpath($file), $pharInfo->getFile());
         self::assertSame(basename($file), $pharInfo->getFileName());
@@ -166,7 +166,7 @@ final class SafePharTest extends TestCase
 
     public function test_it_cleans_itself_up_upon_destruction(): void
     {
-        $pharInfo = new SafePhar(self::FIXTURES_DIR.'/phar/simple-phar.phar');
+        $pharInfo = new PharInfo(self::FIXTURES_DIR.'/phar/simple-phar.phar');
 
         $tmp = $pharInfo->getTmp();
 
@@ -181,8 +181,8 @@ final class SafePharTest extends TestCase
     {
         $file = self::FIXTURES_DIR.'/phar/simple-phar.phar';
 
-        new SafePhar($file);
-        new SafePhar($file);
+        new PharInfo($file);
+        new PharInfo($file);
 
         $this->addToAssertionCount(1);
     }
@@ -194,7 +194,7 @@ final class SafePharTest extends TestCase
         $this->expectException(InvalidPhar::class);
         $this->expectExceptionMessageMatches('/^Could not create a Phar or PharData instance for the file /');
 
-        new SafePhar($file);
+        new PharInfo($file);
     }
 
     private static function getStub(string $path): string


### PR DESCRIPTION
After reviewing the usages I think PharInfo is more descriptive than SafePhar.