### PR TITLE
fix: Remove unnecessary code from the diff command

### DIFF
--- a/src/Console/Command/Diff.php
+++ b/src/Console/Command/Diff.php
@@ -25,14 +25,12 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Path;
-use Throwable;
 use Webmozart\Assert\Assert;
 use function array_map;
 use function count;
 // TODO: migrate to Safe API
 use function explode;
 use function is_string;
-use function KevinGH\Box\check_php_settings;
 use function sprintf;
 use const PHP_EOL;
 
@@ -101,26 +99,9 @@ final class Diff implements Command
 
     public function execute(IO $io): int
     {
-        check_php_settings($io);
-
         $paths = self::getPaths($io);
 
-        try {
-            $diff = new PharDiff(...$paths);
-        } catch (Throwable $throwable) {
-            if ($io->isDebug()) {
-                throw $throwable;
-            }
-
-            $io->writeln(
-                sprintf(
-                    '<error>Could not check the PHARs: %s</error>',
-                    $throwable->getMessage(),
-                ),
-            );
-
-            return ExitCode::FAILURE;
-        }
+        $diff = new PharDiff(...$paths);
 
         $result1 = $this->compareArchives($diff, $io);
         $result2 = $this->compareContents($diff, $io);

--- a/tests/Console/Command/DiffTest.php
+++ b/tests/Console/Command/DiffTest.php
@@ -204,6 +204,9 @@ class DiffTest extends CommandTestCase
 
     public function test_it_cannot_compare_a_non_phar_files(): void
     {
+        $this->expectException(InvalidPhar::class);
+        $this->expectExceptionMessageMatches('/^Could not create a Phar or PharData instance for the file.+not\-a\-phar\.phar.+$/');
+
         $this->commandTester->execute(
             [
                 'command' => 'diff',
@@ -211,11 +214,6 @@ class DiffTest extends CommandTestCase
                 'pharB' => realpath(self::FIXTURES_DIR.'/not-a-phar.phar'),
             ],
         );
-
-        $expected = '/^Could not check the PHARs: Could not create a Phar or PharData instance for the file .+$/';
-
-        self::assertMatchesRegularExpression($expected, $this->commandTester->getDisplay(true));
-        self::assertSame(1, $this->commandTester->getStatusCode());
     }
 
     public function test_it_can_compare_phar_files_without_the_phar_extension(): void


### PR DESCRIPTION
- Restarting the process is no longer needed within the diff command as extracting the PHAR is done in a separate process.
- Catching the exception is no longer necessary or desired since any failure will throw a comprehensive error.