### PR TITLE
test: Remove unnecessary separate processes annotation

### DIFF
--- a/tests/Console/Command/GenerateDockerFileTest.php
+++ b/tests/Console/Command/GenerateDockerFileTest.php
@@ -23,9 +23,6 @@ use function realpath;
 /**
  * @covers \KevinGH\Box\Console\Command\GenerateDockerFile
  *
- * @runTestsInSeparateProcesses This is necessary as instantiating a PHAR in memory may load/autoload some stuff which
- *                              can create undesirable side-effects.
- *
  * @internal
  */
 class GenerateDockerFileTest extends CommandTestCase

--- a/tests/Console/Command/InfoTest.php
+++ b/tests/Console/Command/InfoTest.php
@@ -31,12 +31,6 @@ use function realpath;
  * @covers \KevinGH\Box\Console\Command\Info
  * @covers \KevinGH\Box\Console\Command\PharInfoRenderer
  *
- * @runTestsInSeparateProcesses This is necessary as instantiating a PHAR in memory may load/autoload some stuff which
- *                              can create undesirable side effect.
- *
- * @internal
- */
-/**
  * @internal
  */
 class InfoTest extends CommandTestCase

--- a/tests/Console/Command/ValidateTest.php
+++ b/tests/Console/Command/ValidateTest.php
@@ -27,8 +27,6 @@ use function str_replace;
  * @covers \KevinGH\Box\Console\Command\Validate
  * @covers \KevinGH\Box\Console\MessageRenderer
  *
- * @runTestsInSeparateProcesses
- *
  * @internal
  */
 class ValidateTest extends CommandTestCase

--- a/tests/Phar/PharFactoryTest.php
+++ b/tests/Phar/PharFactoryTest.php
@@ -26,8 +26,6 @@ use const DIRECTORY_SEPARATOR;
  * @covers \KevinGH\Box\Phar\InvalidPhar
  * @covers \KevinGH\Box\Phar\PharFactory
  *
- * @runTestsInSeparateProcesses
- *
  * @internal
  */
 final class PharFactoryTest extends TestCase

--- a/tests/Phar/PharInfoTest.php
+++ b/tests/Phar/PharInfoTest.php
@@ -23,7 +23,6 @@ use function Safe\realpath;
 
 /**
  * @covers \KevinGH\Box\Phar\PharInfo
- * @runTestsInSeparateProcesses
  *
  * @internal
  */


### PR DESCRIPTION
Since PharInfo ensures a memory-safe consumption of the PHAR, some tests no longer need to be executed in separate processes.