### PR TITLE
feat: Rework the diff command output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpdocumentor/type-resolver": "^1.7",
         "psr/log": "^3.0",
+        "sebastian/diff": "^4.0",
         "seld/jsonlint": "^1.9",
         "symfony/console": "^6.1.7",
         "symfony/filesystem": "^6.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff1e129b64f2e02d9c4a3963dbc7d10c",
+    "content-hash": "49fe6f5891e7fa2ae2c999456606c96d",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1777,6 +1777,72 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
             "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -4768,72 +4834,6 @@
                 }
             ],
             "time": "2020-10-26T15:52:27+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "4.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/src/Phar/PharDiff.php
+++ b/src/Phar/PharDiff.php
@@ -61,6 +61,11 @@ final class PharDiff
         return $this->pharInfoB;
     }
 
+    public function equals(): bool
+    {
+        return $this->pharInfoA->equals($this->pharInfoB);
+    }
+
     /**
      * @return null|string|array{string[], string[]}
      */

--- a/tests/Console/Command/DiffTest.php
+++ b/tests/Console/Command/DiffTest.php
@@ -334,7 +334,7 @@ class DiffTest extends CommandTestCase
         }
     }
 
-    private static function commonDiffPharsProvider(): iterable
+    private static function commonDiffPharsProvider(DiffMode $diffMode): iterable
     {
         yield 'same PHAR' => [
             self::FIXTURES_DIR.'/simple-phar-foo.phar',
@@ -353,39 +353,54 @@ class DiffTest extends CommandTestCase
         yield 'different data; same content' => [
             self::FIXTURES_DIR.'/simple-phar-bar.phar',
             self::FIXTURES_DIR.'/simple-phar-bar-compressed.phar',
-            <<<'OUTPUT'
+            sprintf(
+                <<<'OUTPUT'
 
-                 // Comparing the two archives...
+                     // Comparing the two archives...
 
-                Archive: simple-phar-bar.phar
-                Archive Compression: None
-                Files Compression: None
-                Signature: SHA-1
-                Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
-                Metadata: None
-                Contents: 1 file (6.64KB)
+                    Archive: simple-phar-bar.phar
+                    Archive Compression: None
+                    Files Compression: None
+                    Signature: SHA-1
+                    Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                    Metadata: None
+                    Contents: 1 file (6.64KB)
 
-                Archive: simple-phar-bar-compressed.phar
-                Archive Compression: None
-                Files Compression: GZ
-                Signature: SHA-1
-                Signature Hash: 3A388D86C91C36659A043D52C2DEB64E8848DD1A
-                Metadata: None
-                Contents: 1 file (6.65KB)
+                    Archive: simple-phar-bar-compressed.phar
+                    Archive Compression: None
+                    Files Compression: GZ
+                    Signature: SHA-1
+                    Signature Hash: 3A388D86C91C36659A043D52C2DEB64E8848DD1A
+                    Metadata: None
+                    Contents: 1 file (6.65KB)
 
-                 // Comparing the two archives contents...
+                    --- PHAR A
+                    +++ PHAR B
+                    @@ @@
+                     Archive Compression: None
+                    -Files Compression: None
+                    +Files Compression: GZ
+                     Signature: SHA-1
+                    -Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                    +Signature Hash: 3A388D86C91C36659A043D52C2DEB64E8848DD1A
+                     Metadata: None
+                    -Contents: 1 file (6.64KB)
+                    +Contents: 1 file (6.65KB)
 
-                 [OK] The contents are identical
+                     // Comparing the two archives contents (%s diff)...
 
+                    No difference could be observed with this mode.
 
-                OUTPUT,
+                    OUTPUT,
+                $diffMode->value,
+            ),
             ExitCode::FAILURE,
         ];
     }
 
     private static function listDiffPharsProvider(): iterable
     {
-        yield from self::commonDiffPharsProvider();
+        yield from self::commonDiffPharsProvider(DiffMode::LIST);
 
         yield 'different files' => [
             self::FIXTURES_DIR.'/simple-phar-foo.phar',
@@ -410,7 +425,18 @@ class DiffTest extends CommandTestCase
                 Metadata: None
                 Contents: 1 file (6.64KB)
 
-                 // Comparing the two archives contents...
+                --- PHAR A
+                +++ PHAR B
+                @@ @@
+                 Archive Compression: None
+                 Files Compression: None
+                 Signature: SHA-1
+                -Signature Hash: 311080EF8E479CE18D866B744B7D467880BFBF57
+                +Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                 Metadata: None
+                 Contents: 1 file (6.64KB)
+
+                 // Comparing the two archives contents (list diff)...
 
                 --- Files present in "simple-phar-foo.phar" but not in "simple-phar-bar.phar"
                 +++ Files present in "simple-phar-bar.phar" but not in "simple-phar-foo.phar"
@@ -449,10 +475,21 @@ class DiffTest extends CommandTestCase
                 Metadata: None
                 Contents: 1 file (6.61KB)
 
-                 // Comparing the two archives contents...
+                --- PHAR A
+                +++ PHAR B
+                @@ @@
+                 Archive Compression: None
+                 Files Compression: None
+                 Signature: SHA-1
+                -Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                +Signature Hash: 122A636B8BB0348C9514833D70281EF6306A5BF5
+                 Metadata: None
+                -Contents: 1 file (6.64KB)
+                +Contents: 1 file (6.61KB)
 
-                 [OK] The contents are identical
+                 // Comparing the two archives contents (list diff)...
 
+                No difference could be observed with this mode.
 
                 OUTPUT,
             ExitCode::FAILURE,
@@ -461,7 +498,7 @@ class DiffTest extends CommandTestCase
 
     public static function gitDiffPharsProvider(): iterable
     {
-        yield from self::commonDiffPharsProvider();
+        yield from self::commonDiffPharsProvider(DiffMode::GIT);
 
         yield 'different files' => [
             self::FIXTURES_DIR.'/simple-phar-foo.phar',
@@ -539,7 +576,7 @@ class DiffTest extends CommandTestCase
 
     public static function GNUDiffPharsProvider(): iterable
     {
-        yield from self::commonDiffPharsProvider();
+        yield from self::commonDiffPharsProvider(DiffMode::GNU);
 
         yield 'different files' => [
             self::FIXTURES_DIR.'/simple-phar-foo.phar',
@@ -564,7 +601,18 @@ class DiffTest extends CommandTestCase
                 Metadata: None
                 Contents: 1 file (6.64KB)
 
-                 // Comparing the two archives contents...
+                --- PHAR A
+                +++ PHAR B
+                @@ @@
+                 Archive Compression: None
+                 Files Compression: None
+                 Signature: SHA-1
+                -Signature Hash: 311080EF8E479CE18D866B744B7D467880BFBF57
+                +Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                 Metadata: None
+                 Contents: 1 file (6.64KB)
+
+                 // Comparing the two archives contents (gnu diff)...
 
                 Only in simple-phar-bar.phar: bar.php
                 Only in simple-phar-foo.phar: foo.php
@@ -597,7 +645,19 @@ class DiffTest extends CommandTestCase
                     Metadata: None
                     Contents: 1 file (6.61KB)
 
-                     // Comparing the two archives contents...
+                    --- PHAR A
+                    +++ PHAR B
+                    @@ @@
+                     Archive Compression: None
+                     Files Compression: None
+                     Signature: SHA-1
+                    -Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                    +Signature Hash: 122A636B8BB0348C9514833D70281EF6306A5BF5
+                     Metadata: None
+                    -Contents: 1 file (6.64KB)
+                    +Contents: 1 file (6.61KB)
+
+                     // Comparing the two archives contents (gnu diff)...
 
                     diff --exclude=.phar_meta.json simple-phar-bar.phar/bar.php simple-phar-baz.phar/bar.php
                     3c3
@@ -610,9 +670,35 @@ class DiffTest extends CommandTestCase
 
                      // Comparing the two archives...
 
-                     [OK] The two archives are identical
+                    Archive: simple-phar-bar.phar
+                    Archive Compression: None
+                    Files Compression: None
+                    Signature: SHA-1
+                    Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                    Metadata: None
+                    Contents: 1 file (6.64KB)
 
-                     // Comparing the two archives contents...
+                    Archive: simple-phar-baz.phar
+                    Archive Compression: None
+                    Files Compression: None
+                    Signature: SHA-1
+                    Signature Hash: 122A636B8BB0348C9514833D70281EF6306A5BF5
+                    Metadata: None
+                    Contents: 1 file (6.61KB)
+
+                    --- PHAR A
+                    +++ PHAR B
+                    @@ @@
+                     Archive Compression: None
+                     Files Compression: None
+                     Signature: SHA-1
+                    -Signature Hash: 9ADC09F73909EDF14F8A4ABF9758B6FFAD1BBC51
+                    +Signature Hash: 122A636B8BB0348C9514833D70281EF6306A5BF5
+                     Metadata: None
+                    -Contents: 1 file (6.64KB)
+                    +Contents: 1 file (6.61KB)
+
+                     // Comparing the two archives contents (gnu diff)...
 
                     diff '--exclude=.phar_meta.json' simple-phar-bar.phar/bar.php simple-phar-baz.phar/bar.php
                     3c3


### PR DESCRIPTION
- Always display a summary of both archives upon equality failure.
- Provide a human-readable diff of the archives when possible.
- Make the message more explicit that if no diff was found for the archives content, this is true for the selected diff mode, i.e. a difference may be found with another diff mode.