### PR TITLE
feat: Change from filename to checksum as the default diff mode

### DIFF
--- a/src/Console/Command/Diff.php
+++ b/src/Console/Command/Diff.php
@@ -98,7 +98,7 @@ final class Diff implements Command
                             DiffMode::values(),
                         ),
                     ),
-                    DiffMode::FILE_NAME->value,
+                    DiffMode::CHECKSUM->value,
                 ),
                 new InputOption(
                     self::CHECK_OPTION,


### PR DESCRIPTION
Now that the checksum is a lot easier to do than before, I think it makes more sense to pick it as the default diff mode.

It will not be as easily understandable than GNU or Git, but will show the problematic files whilst being more available than the GNU/git diff modes.