### PR TITLE
fix: Get the raw output for the Composer version

### DIFF
--- a/src/Composer/ComposerOrchestrator.php
+++ b/src/Composer/ComposerOrchestrator.php
@@ -75,7 +75,7 @@ final class ComposerOrchestrator
         $logger = new CompilerLogger($io ?? IO::createNull());
 
         $composerExecutable = $composerBin ?? self::retrieveComposerExecutable();
-        $getVersionProcess = new Process([$composerExecutable, '--version']);
+        $getVersionProcess = new Process([$composerExecutable, '--version', '--no-ansi']);
 
         $logger->log(
             CompilerLogger::CHEVRON_PREFIX,

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -858,7 +858,7 @@ class CompileTest extends FileSystemTestCase
 
             ? Removing the existing PHAR "/path/to/tmp/test.phar"
             ? Checking Composer compatibility
-                > '/usr/local/bin/composer' '--version'
+                > '/usr/local/bin/composer' '--version' '--no-ansi'
                 > 2.5.0 (Box requires ^2.2.0)
                 > Supported version detected
             ? Registering compactors
@@ -986,7 +986,7 @@ class CompileTest extends FileSystemTestCase
 
             ? Removing the existing PHAR "/path/to/tmp/test.phar"
             ? Checking Composer compatibility
-                > '/usr/local/bin/composer' '--version'
+                > '/usr/local/bin/composer' '--version' '--no-ansi'
                 > 2.5.0 (Box requires ^2.2.0)
                 > Supported version detected
             ? Registering compactors


### PR DESCRIPTION
I suspect in some context the current `ComposerOrchestrator::getVersion()` could get the ANSI output for which the regex we use afterwards to extract the Composer version does not work. Rather than fixing the regex which is not trivial, it makes more sense to guarantee a no-ANSI output.

Fixes #1004. 