### PR TITLE
fix: Do not rethrow the exception in the info command

### DIFF
--- a/src/Console/Command/Info.php
+++ b/src/Console/Command/Info.php
@@ -24,7 +24,6 @@ use Phar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Path;
-use Throwable;
 use function implode;
 use function is_array;
 use function realpath;
@@ -129,30 +128,15 @@ final class Info implements Command
         $maxDepth = self::getMaxDepth($io);
         $mode = $io->getOption(self::MODE_OPT)->asStringChoice(self::MODES);
 
-        try {
-            $pharInfo = new PharInfo($file);
+        $pharInfo = new PharInfo($file);
 
-            return self::showPharInfo(
-                $pharInfo,
-                $io->getOption(self::LIST_OPT)->asBoolean(),
-                -1 === $maxDepth ? false : $maxDepth,
-                'indent' === $mode,
-                $io,
-            );
-        } catch (Throwable $throwable) {
-            if ($io->isDebug()) {
-                throw $throwable;
-            }
-
-            $io->error(
-                sprintf(
-                    'Could not read the file "%s".',
-                    $file,
-                ),
-            );
-
-            return ExitCode::FAILURE;
-        }
+        return self::showPharInfo(
+            $pharInfo,
+            $io->getOption(self::LIST_OPT)->asBoolean(),
+            -1 === $maxDepth ? false : $maxDepth,
+            'indent' === $mode,
+            $io,
+        );
     }
 
     /**

--- a/tests/Console/Command/InfoTest.php
+++ b/tests/Console/Command/InfoTest.php
@@ -24,8 +24,6 @@ use Phar;
 use Symfony\Component\Console\Output\OutputInterface;
 use function extension_loaded;
 use function implode;
-use function preg_replace;
-use function Safe\realpath;
 
 /**
  * @covers \KevinGH\Box\Console\Command\Info
@@ -602,31 +600,17 @@ class InfoTest extends CommandTestCase
         }
     }
 
-    public function test_it_cannot_provide_info_about_an_invalid_phar_without_extension(): void
+    public function test_it_cannot_provide_info_about_an_invalid_phar(): void
     {
         $file = self::FIXTURES.'/foo';
+
+        $this->expectException(InvalidPhar::class);
 
         $this->commandTester->execute(
             [
                 'command' => 'info',
                 'phar' => $file,
             ],
-        );
-
-        $expectedPath = realpath($file);
-
-        $expected = <<<OUTPUT
-
-
-             [ERROR] Could not read the file "{$expectedPath}".
-
-
-            OUTPUT;
-
-        $this->assertSameOutput(
-            $expected,
-            ExitCode::FAILURE,
-            static fn ($output) => preg_replace('/file[\ \n]+"/', 'file "', $output),
         );
     }
 


### PR DESCRIPTION
Since `PharInfo` has been introduced, the exception should be clear and easily understandable so this extra catch logic is no longer necessary.