### PR TITLE
fix: Require missing iconv and mbstring dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-iconv": "*",
+        "ext-mbstring": "*",
         "ext-phar": "*",
         "ext-sodium": "*",
         "composer-plugin-api": "^2.2",
@@ -40,6 +42,8 @@
         "symfony/console": "^6.1.7",
         "symfony/filesystem": "^6.1.5",
         "symfony/finder": "^6.1.3",
+        "symfony/polyfill-iconv": "^1.28",
+        "symfony/polyfill-mbstring": "^1.28",
         "symfony/process": "^6.1.3",
         "symfony/var-dumper": "^6.1.6",
         "webmozart/assert": "^1.11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49fe6f5891e7fa2ae2c999456606c96d",
+    "content-hash": "906c2401750976bf998ace8b2b97b067",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2333,6 +2333,89 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6de50471469b8c9afc38164452ab2b6170ee71c1",
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -5691,6 +5774,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1",
+        "ext-iconv": "*",
+        "ext-mbstring": "*",
         "ext-phar": "*",
         "ext-sodium": "*",
         "composer-plugin-api": "^2.2"


### PR DESCRIPTION
- `ext-mbstring` is required and to allow it to work as a PHAR the polyfill is added.
- `symfony/polyfill-mbstring` require `iconv` (see https://github.com/symfony/symfony/issues/52207).