### PR TITLE
fix: Ensure the PHP processes are restarted properly

### DIFF
--- a/src/Composer/ComposerProcessFactory.php
+++ b/src/Composer/ComposerProcessFactory.php
@@ -124,7 +124,7 @@ class ComposerProcessFactory
 
     private static function getDefaultEnvVars(): array
     {
-        $vars = [];
+        $vars = ['COMPOSER_ORIGINAL_INIS' => ''];
 
         if ('1' === (string) getenv(BOX_ALLOW_XDEBUG)) {
             $vars['COMPOSER_ALLOW_XDEBUG'] = '1';

--- a/src/Console/Php/PhpSettingsHandler.php
+++ b/src/Console/Php/PhpSettingsHandler.php
@@ -47,6 +47,7 @@ final class PhpSettingsHandler extends XdebugHandler
         $this->logger = $logger;
 
         $this->pharReadonly = PharPhpSettings::isReadonly();
+        $this->setPersistent();
     }
 
     public function check(): void


### PR DESCRIPTION
- Use the persistent setting: any sub-process should use the same settings.
- Reset `COMPOSER_ORIGINAL_INIS` to avoid the buggy Flex code (see https://github.com/symfony/flex/pull/995).

Closes #1089, #988.