### PR TITLE
ci: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This will essentially run `composer update` once weekly and open a PR for you to approve and merge.

There are lots of options to play with here if you want, such as running more or less often or only running `composer update` for single dependencies at a time (i.e., separate PRs for every update to Symfony, PSR Log, etc...) But I find this to be a nice balance.

If you're feeling especially spicy, it's even possible to [automatically merge Dependabot PRs](https://github.com/acquia/.github/blob/main/workflow-templates/automerge.yml) after tests pass, but I'd recommend doing it manually for a bit to get used to it.