### PR TITLE
fix: Fix the process command whitelist term

### DIFF
--- a/src/Console/Command/Process.php
+++ b/src/Console/Command/Process.php
@@ -141,7 +141,7 @@ final class Process implements Command
             if (null !== $symbolsRegistry) {
                 $io->writeln([
                     '',
-                    'Whitelist:',
+                    'Symbols Registry:',
                     '',
                     '<comment>"""</comment>',
                     self::exportSymbolsRegistry($symbolsRegistry, $io),

--- a/tests/Console/Command/ProcessTest.php
+++ b/tests/Console/Command/ProcessTest.php
@@ -204,7 +204,7 @@ class ProcessTest extends CommandTestCase
 
             """
 
-            Whitelist:
+            Symbols Registry:
 
             """
             Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#140


### PR DESCRIPTION
The term "whitelist" is no longer correct.