### PR TITLE
doc: Remove installation doc entry for PHAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ For the full documentation see https://box-project.github.io/box.
 ## Table of Contents
 
 1. [Installation](doc/installation.md#installation)
-    1. [PHAR](doc/installation.md#phar)
     1. [Phive](doc/installation.md#phive)
     1. [Composer](doc/installation.md#composer)
     1. [Homebrew](doc/installation.md#homebrew)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,17 +1,10 @@
 # Installation
 
-1. [PHAR](#phar)
 1. [Phive](#phive)
 1. [Composer](#composer)
 1. [Homebrew](#homebrew)
 1. [GitHub](#github)
 1. [Docker](#docker)
-
-
-## PHAR
-
-The preferred method of installation is to use the Box PHAR which can be downloaded from the most recent
-[Github Release][releases]. This method ensures you will not have any dependency conflict issue.
 
 
 ## Phive


### PR DESCRIPTION
The other methods are now preferred and downloading via the GitHub release has a new doc entry (`#github`) which contains more detailed steps.