### PR TITLE
refactor: Make Box::getPhar() internal

### DIFF
--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -48,7 +48,6 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Filesystem\Path;
-use Webmozart\Assert\Assert;
 use function array_map;
 use function array_shift;
 use function count;
@@ -278,7 +277,7 @@ final class Compile implements CommandAware
         self::checkComposerFiles($box, $config, $logger);
 
         if ($debug) {
-            $box->getPhar()->extractTo(self::DEBUG_DIR, null, true);
+            $box->extractTo(self::DEBUG_DIR, true);
         }
 
         self::configureCompressionAlgorithm(
@@ -594,7 +593,7 @@ final class Compile implements CommandAware
 
             $stub = self::createStub($config, $main, $checkRequirements, $logger);
 
-            $box->getPhar()->setStub($stub);
+            $box->setStub($stub);
 
             return;
         }
@@ -613,17 +612,8 @@ final class Compile implements CommandAware
             return;
         }
 
-        $aliasWasAdded = $box->getPhar()->setAlias($config->getAlias());
-
-        Assert::true(
-            $aliasWasAdded,
-            sprintf(
-                'The alias "%s" is invalid. See Phar::setAlias() documentation for more information.',
-                $config->getAlias(),
-            ),
-        );
-
-        $box->getPhar()->setDefaultStub($main);
+        $box->setAlias($config->getAlias());
+        $box->setDefaultStub($main);
 
         $logger->log(
             CompilerLogger::QUESTION_MARK_PREFIX,
@@ -648,7 +638,7 @@ final class Compile implements CommandAware
                 is_string($metadata) ? $metadata : var_export($metadata, true),
             );
 
-            $box->getPhar()->setMetadata($metadata);
+            $box->setMetadata($metadata);
         }
     }
 
@@ -763,9 +753,7 @@ final class Compile implements CommandAware
         $key = $config->getPrivateKeyPath();
 
         if (null === $key) {
-            $box->getPhar()->setSignatureAlgorithm(
-                $config->getSigningAlgorithm()->value,
-            );
+            $box->sign($config->getSigningAlgorithm());
 
             return;
         }

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -1437,7 +1437,7 @@ class BoxTest extends FileSystemTestCase
 
         $this->configureHelloWorldPhar();
 
-        $this->box->sign($key, $password);
+        $this->box->signUsingKey($key, $password);
 
         self::assertNotSame([], $phar->getSignature(), 'Expected the PHAR to be signed.');
         self::assertIsString($phar->getSignature()['hash'], 'Expected the PHAR signature hash to be a string.');
@@ -1462,7 +1462,7 @@ class BoxTest extends FileSystemTestCase
         $this->configureHelloWorldPhar();
 
         try {
-            $this->box->sign($key, $password);
+            $this->box->signUsingKey($key, $password);
 
             self::fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {
@@ -1482,7 +1482,7 @@ class BoxTest extends FileSystemTestCase
         $this->configureHelloWorldPhar();
 
         try {
-            $this->box->sign($key, $password);
+            $this->box->signUsingKey($key, $password);
 
             self::fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {


### PR DESCRIPTION
The `Phar` instance might be unset within `Box` hence it should not be leaked to any production code.