### PR TITLE
ci: Fix the release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,8 @@ jobs:
         needs:
             - build-phar
         if: github.event_name == 'release'
+        permissions:
+            contents: write
         steps:
             -   uses: actions/download-artifact@v3
                 with:


### PR DESCRIPTION
See https://github.com/humbug/php-scoper/pull/923.