### PR TITLE
ci: Fix conditional required workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,6 +1,5 @@
 name: Benchmark Tests
 
-# To be aware it need to be the counter-part of benchmark-empty.yaml.
 on:
     pull_request: ~
 

--- a/.github/workflows/docs-empty.yaml
+++ b/.github/workflows/docs-empty.yaml
@@ -1,10 +1,13 @@
 # Fallback workflow to be able to have the branch protection enabled at all times.
-name: Empty Benchmark Tests
+name: Null Docs
 
 on:
-    # To be aware it need to be the counter-part of benchmark.yaml.
-    push:
-        branches: [ main ]
+    # To be aware it need to be the counter-part of docs.yaml.
+    pull_request:
+        paths-ignore:
+            - doc/**
+            - mkdocs.yaml
+            - .github/workflows/docs.yaml
 
 # See https://stackoverflow.com/a/72408109
 concurrency:
@@ -16,7 +19,7 @@ jobs:
     # the protected branch rules as opposed to the tests one above which
     # may change regularly.
     validate-tests:
-        name: Benchmark tests status
+        name: Docs status
         runs-on: ubuntu-latest
         steps:
             - name: Successful run

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: GitHub-Pages
+name: Docs
 
 on:
     push:
@@ -7,12 +7,13 @@ on:
         paths:
             - doc/**
             - mkdocs.yaml
-            - .github/workflows/gh-pages.yaml
+            - .github/workflows/docs.yaml
+    # To be aware it need to be the counter-part of docs-empty.yaml.
     pull_request:
         paths:
             - doc/**
             - mkdocs.yaml
-            - .github/workflows/gh-pages.yaml
+            - .github/workflows/docs.yaml
 
 # See https://stackoverflow.com/a/72408109
 concurrency:


### PR DESCRIPTION
- Remove `empty-benchmark.yaml`: it is not needed as the rule for required workflows apply to pull requests only.
- Rename `GitHub-Pages` to `Docs`.
- Introduce the `docs-empty.yaml` analogue to `empty-benchmark.yaml` prior to its removal.