### PR TITLE
feat: No longer fail on non satisfiable PHP constraint when generating Docker file

### DIFF
--- a/src/DockerFileGenerator.php
+++ b/src/DockerFileGenerator.php
@@ -44,7 +44,6 @@ final class DockerFileGenerator
         Dockerfile;
 
     private const PHP_DOCKER_IMAGES = [
-        // TODO: allow future images
         '8.2.0' => '8.2-cli-alpine',
         '8.1.0' => '8.1-cli-alpine',
         '8.0.0' => '8.0-cli-alpine',
@@ -53,6 +52,7 @@ final class DockerFileGenerator
         '7.2.0' => '7.2-cli-alpine',
         '7.1.0' => '7.1-cli-alpine',
         '7.0.0' => '7-cli-alpine',
+        '*' => 'to-define-manually',
     ];
 
     private readonly string $image;
@@ -128,6 +128,10 @@ final class DockerFileGenerator
 
         foreach (self::PHP_DOCKER_IMAGES as $php => $image) {
             foreach ($conditions as $condition) {
+                if ('*' === $php) {
+                    return $image;
+                }
+
                 if (false === Semver::satisfies($php, $condition)) {
                     continue 2;
                 }


### PR DESCRIPTION
When generating a Dockerfile the PHP image token is a "nice to have". The docker image itself is meant as generating a helpful template rather than a definite file that should not be touched.

With this in mind, failing to generate the template because the appropriate PHP image could not be determine is rather annoying as it is something easily fixable by the user whilst the list of templates is a bit more of an inaccessible content.