### PR TITLE
test(perf): Reduce the benchmark requirements

### DIFF
--- a/bin/bench-test.php
+++ b/bin/bench-test.php
@@ -34,7 +34,7 @@ $noParallelTime = $meanTimes['with compactors; no parallel processing'];
 
 $formatMeanTime = static fn (float $mean) => number_format($mean).'µs';
 
-$maxParallelTimeTarget = .8 * $noParallelTime;
+$maxParallelTimeTarget = .9 * $noParallelTime;
 
 echo 'Benchmark results check:'.PHP_EOL;
 echo '========================'.PHP_EOL;


### PR DESCRIPTION
Since GitHub Actions has a very limited amount of cores (2 most of the time), the benefits brought by the parallelization are very limited hence to avoid having the pipeline all the time red it should be made more flexibile.