### PR TITLE
chore: Remove dependency on PHP-Parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "humbug/php-scoper": "^0.18.6",
         "justinrainbow/json-schema": "^5.2.12",
         "nikic/iter": "^2.2",
-        "nikic/php-parser": "^4.15.2",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpdocumentor/type-resolver": "^1.7",
         "psr/log": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9117e2c9c128be5e863fccf684a0a21e",
+    "content-hash": "ef3c7bc84d266e28f33e96b7e314701d",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
Box does not use PHP-Parser directly hence it should not require it allowing PHP-Scoper to update it as it pleases.