### PR TITLE
test(perf): Remove noise from AppRequirementFactoryBench

### DIFF
--- a/tests/Benchmark/AppRequirementFactoryBench.php
+++ b/tests/Benchmark/AppRequirementFactoryBench.php
@@ -28,9 +28,27 @@ final readonly class AppRequirementFactoryBench
 {
     private const FIXTURES = __DIR__.'/../../fixtures/bench/requirement-checker';
 
+    private ComposerJson $composerJson;
+    private ComposerLock $composerLock;
+
     public function setUp(): void
     {
         self::assertVendorsAreInstalled();
+
+        $this->composerJson = new ComposerJson(
+            '',
+            json_decode(
+                file_get_contents(self::FIXTURES.'/composer.json'),
+                true,
+            ),
+        );
+        $this->composerLock = new ComposerLock(
+            '',
+            json_decode(
+                file_get_contents(self::FIXTURES.'/composer.lock'),
+                true,
+            ),
+        );
     }
 
     #[Iterations(1000)]
@@ -38,20 +56,8 @@ final readonly class AppRequirementFactoryBench
     public function bench(): void
     {
         AppRequirementsFactory::create(
-            new ComposerJson(
-                '',
-                json_decode(
-                    file_get_contents(self::FIXTURES.'/composer.json'),
-                    true,
-                ),
-            ),
-            new ComposerLock(
-                '',
-                json_decode(
-                    file_get_contents(self::FIXTURES.'/composer.lock'),
-                    true,
-                ),
-            ),
+            $this->composerJson,
+            $this->composerLock,
             CompressionAlgorithm::BZ2,
         );
     }


### PR DESCRIPTION
Creating the `ComposerJson` and `ComposerLock` files are not exactly free given that they have an IO operation. Hence, it makes more sense to move their instantiation to the setup method to reduce the noise from the actual benchmark.