### PR TITLE
feat: Provide a non optimized requirement list

### DIFF
--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -39,7 +39,7 @@ final class AppRequirementsFactory
                 $composerLock,
                 $compressionAlgorithm,
             )
-            ->getAll();
+            ->all();
     }
 
     public function create(

--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -28,11 +28,39 @@ final class AppRequirementsFactory
 {
     private const SELF_PACKAGE = null;
 
+    public function createUnfiltered(
+        ComposerJson $composerJson,
+        ComposerLock $composerLock,
+        CompressionAlgorithm $compressionAlgorithm,
+    ): Requirements {
+        return $this
+            ->createBuilder(
+                $composerJson,
+                $composerLock,
+                $compressionAlgorithm,
+            )
+            ->getAll();
+    }
+
     public function create(
         ComposerJson $composerJson,
         ComposerLock $composerLock,
         CompressionAlgorithm $compressionAlgorithm,
     ): Requirements {
+        return $this
+            ->createBuilder(
+                $composerJson,
+                $composerLock,
+                $compressionAlgorithm,
+            )
+            ->build();
+    }
+
+    private function createBuilder(
+        ComposerJson $composerJson,
+        ComposerLock $composerLock,
+        CompressionAlgorithm $compressionAlgorithm,
+    ): RequirementsBuilder {
         $requirementsBuilder = new RequirementsBuilder();
 
         self::retrievePhpVersionRequirements($requirementsBuilder, $composerJson, $composerLock);
@@ -40,7 +68,7 @@ final class AppRequirementsFactory
         self::collectComposerLockExtensionRequirements($composerLock, $requirementsBuilder);
         self::collectComposerJsonExtensionRequirements($composerJson, $requirementsBuilder);
 
-        return $requirementsBuilder->build();
+        return $requirementsBuilder;
     }
 
     private static function retrievePhpVersionRequirements(

--- a/src/RequirementChecker/Requirement.php
+++ b/src/RequirementChecker/Requirement.php
@@ -86,6 +86,26 @@ final readonly class Requirement
         );
     }
 
+    public static function forProvidedExtension(string $extension, ?string $packageName): self
+    {
+        return new self(
+            RequirementType::PROVIDED_EXTENSION,
+            $extension,
+            $packageName,
+            null === $packageName
+                ? sprintf(
+                    'This application provides the extension "%s".',
+                    $extension,
+                )
+                : sprintf(
+                    'The package "%s" provides the extension "%s".',
+                    $packageName,
+                    $extension,
+                ),
+            '',
+        );
+    }
+
     public static function forConflictingExtension(string $extension, ?string $packageName): self
     {
         return new self(

--- a/src/RequirementChecker/Requirement.php
+++ b/src/RequirementChecker/Requirement.php
@@ -102,7 +102,16 @@ final readonly class Requirement
                     $packageName,
                     $extension,
                 ),
-            '',
+            null === $packageName
+                ? sprintf(
+                    'This application does not require the extension "%s", it is provided by the application itself.',
+                    $extension,
+                )
+                : sprintf(
+                    'This application does not require the extension "%s", it is provided by the package "%s".',
+                    $packageName,
+                    $extension,
+                ),
         );
     }
 

--- a/src/RequirementChecker/RequirementType.php
+++ b/src/RequirementChecker/RequirementType.php
@@ -18,5 +18,6 @@ enum RequirementType: string
 {
     case PHP = 'php';
     case EXTENSION = 'extension';
+    case PROVIDED_EXTENSION = 'provided-extension';
     case EXTENSION_CONFLICT = 'extension-conflict';
 }

--- a/src/RequirementChecker/RequirementsBuilder.php
+++ b/src/RequirementChecker/RequirementsBuilder.php
@@ -49,6 +49,40 @@ final class RequirementsBuilder
         $this->conflictingExtensions[$extension->name][] = $source;
     }
 
+    public function getAll(): Requirements
+    {
+        $requirements = $this->predefinedRequirements;
+
+        foreach ($this->getUnfilteredSortedRequiredExtensions() as $extensionName => $sources) {
+            foreach ($sources as $source) {
+                $requirements[] = Requirement::forRequiredExtension(
+                    $extensionName,
+                    $source,
+                );
+            }
+        }
+
+        foreach ($this->getSortedProvidedExtensions() as $extensionName => $sources) {
+            foreach ($sources as $source) {
+                $requirements[] = Requirement::forProvidedExtension(
+                    $extensionName,
+                    $source,
+                );
+            }
+        }
+
+        foreach ($this->getSortedConflictedExtensions() as $extensionName => $sources) {
+            foreach ($sources as $source) {
+                $requirements[] = Requirement::forConflictingExtension(
+                    $extensionName,
+                    $source,
+                );
+            }
+        }
+
+        return new Requirements($requirements);
+    }
+
     public function build(): Requirements
     {
         $requirements = $this->predefinedRequirements;
@@ -72,6 +106,31 @@ final class RequirementsBuilder
         }
 
         return new Requirements($requirements);
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function getUnfilteredSortedRequiredExtensions(): array
+    {
+        return array_map(
+            self::createSortedDistinctList(...),
+            self::sortByExtensionName(
+                $this->requiredExtensions,
+            ),
+        );
+    }
+    /**
+     * @return array<string, list<string>>
+     */
+    private function getSortedProvidedExtensions(): array
+    {
+        return array_map(
+            self::createSortedDistinctList(...),
+            self::sortByExtensionName(
+                $this->providedExtensions,
+            ),
+        );
     }
 
     /**

--- a/src/RequirementChecker/RequirementsBuilder.php
+++ b/src/RequirementChecker/RequirementsBuilder.php
@@ -49,7 +49,7 @@ final class RequirementsBuilder
         $this->conflictingExtensions[$extension->name][] = $source;
     }
 
-    public function getAll(): Requirements
+    public function all(): Requirements
     {
         $requirements = $this->predefinedRequirements;
 
@@ -120,6 +120,7 @@ final class RequirementsBuilder
             ),
         );
     }
+
     /**
      * @return array<string, list<string>>
      */

--- a/tests/RequirementChecker/RequirementTest.php
+++ b/tests/RequirementChecker/RequirementTest.php
@@ -95,6 +95,42 @@ final class RequirementTest extends TestCase
         self::assertItCanBeCreatedFromItsArrayForm($requirement, $actual);
     }
 
+    public function test_it_can_be_created_for_a_provided_extension_constraint(): void
+    {
+        $requirement = Requirement::forProvidedExtension('mbstring', null);
+
+        $expected = [
+            'type' => 'provided-extension',
+            'condition' => 'mbstring',
+            'source' => null,
+            'message' => 'This application provides the extension "mbstring".',
+            'helpMessage' => 'This application does not require the extension "mbstring", it is provided by the application itself.',
+        ];
+
+        $actual = $requirement->toArray();
+
+        self::assertSame($expected, $actual);
+        self::assertItCanBeCreatedFromItsArrayForm($requirement, $actual);
+    }
+
+    public function test_it_can_be_created_for_a_provided_extension_constraint_for_a_package(): void
+    {
+        $requirement = Requirement::forProvidedExtension('mbstring', 'box/test');
+
+        $expected = [
+            'type' => 'provided-extension',
+            'condition' => 'mbstring',
+            'source' => 'box/test',
+            'message' => 'The package "box/test" provides the extension "mbstring".',
+            'helpMessage' => 'This application does not require the extension "box/test", it is provided by the package "mbstring".',
+        ];
+
+        $actual = $requirement->toArray();
+
+        self::assertSame($expected, $actual);
+        self::assertItCanBeCreatedFromItsArrayForm($requirement, $actual);
+    }
+
     public function test_it_can_be_created_for_a_conflicting_extension_constraint(): void
     {
         $requirement = Requirement::forConflictingExtension('mbstring', null);

--- a/tests/RequirementChecker/RequirementsBuilderTest.php
+++ b/tests/RequirementChecker/RequirementsBuilderTest.php
@@ -25,13 +25,19 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(RequirementsBuilder::class)]
 final class RequirementsBuilderTest extends TestCase
 {
+    private RequirementsBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new RequirementsBuilder();
+    }
+
     public function test_it_can_build_requirements_from_an_empty_list(): void
     {
-        $requirements = (new RequirementsBuilder())->build();
-
         $expected = new Requirements([]);
 
-        self::assertEquals($expected, $requirements);
+        $this->assertBuiltRequirementsEquals($expected);
+        $this->assertAllRequirementsEquals($expected);
     }
 
     public function test_it_can_build_requirements_from_predefined_requirements(): void
@@ -42,39 +48,36 @@ final class RequirementsBuilderTest extends TestCase
             Requirement::forConflictingExtension('http', null),
         ];
 
-        $builder = new RequirementsBuilder();
-
         foreach ($predefinedRequirements as $predefinedRequirement) {
-            $builder->addRequirement($predefinedRequirement);
+            $this->builder->addRequirement($predefinedRequirement);
         }
 
         $expected = new Requirements($predefinedRequirements);
-        $actual = $builder->build();
 
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expected);
+        $this->assertAllRequirementsEquals($expected);
     }
 
     public function test_it_can_build_requirements_from_required_extensions(): void
     {
-        $builder = new RequirementsBuilder();
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package1',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package2',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('phar'),
             'package1',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('openssl'),
             'package3',
         );
         // Duplicate
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('openssl'),
             'package3',
         );
@@ -86,51 +89,51 @@ final class RequirementsBuilderTest extends TestCase
             Requirement::forRequiredExtension('phar', 'package1'),
         ]);
 
-        $actual = $builder->build();
-
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expected);
+        $this->assertAllRequirementsEquals($expected);
     }
 
     public function test_it_can_build_requirements_from_provided_extensions(): void
     {
-        $builder = new RequirementsBuilder();
-        $builder->addProvidedExtension(
+        $this->builder->addProvidedExtension(
             new Extension('http'),
             'package1',
         );
-        $builder->addProvidedExtension(
+        $this->builder->addProvidedExtension(
             new Extension('http'),
             'package2',
         );
 
-        $expected = new Requirements([]);
+        $expectedBuiltRequirements = new Requirements([]);
+        $expectedAllRequirements = new Requirements([
+            Requirement::forProvidedExtension('http', 'package1'),
+            Requirement::forProvidedExtension('http', 'package2'),
+        ]);
 
-        $actual = $builder->build();
-
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);
+        $this->assertAllRequirementsEquals($expectedAllRequirements);
     }
 
     public function test_it_can_build_requirements_from_conflicting_extensions(): void
     {
-        $builder = new RequirementsBuilder();
-        $builder->addConflictingExtension(
+        $this->builder->addConflictingExtension(
             new Extension('http'),
             'package1',
         );
-        $builder->addConflictingExtension(
+        $this->builder->addConflictingExtension(
             new Extension('http'),
             'package2',
         );
-        $builder->addConflictingExtension(
+        $this->builder->addConflictingExtension(
             new Extension('phar'),
             'package1',
         );
-        $builder->addConflictingExtension(
+        $this->builder->addConflictingExtension(
             new Extension('openssl'),
             'package3',
         );
         // Duplicate
-        $builder->addConflictingExtension(
+        $this->builder->addConflictingExtension(
             new Extension('openssl'),
             'package3',
         );
@@ -142,88 +145,96 @@ final class RequirementsBuilderTest extends TestCase
             Requirement::forConflictingExtension('phar', 'package1'),
         ]);
 
-        $actual = $builder->build();
-
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expected);
+        $this->assertAllRequirementsEquals($expected);
     }
 
     public function test_it_removes_extension_requirements_if_they_are_provided(): void
     {
-        $builder = new RequirementsBuilder();
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package1',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package2',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('phar'),
             'package1',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('openssl'),
             'package3',
         );
-        $builder->addProvidedExtension(
+        $this->builder->addProvidedExtension(
             new Extension('http'),
             'package3',
         );
 
-        $expected = new Requirements([
+        $expectedBuiltRequirements = new Requirements([
             Requirement::forRequiredExtension('openssl', 'package3'),
             Requirement::forRequiredExtension('phar', 'package1'),
         ]);
+        $expectedAllRequirements = new Requirements([
+            Requirement::forRequiredExtension('http', 'package1'),
+            Requirement::forRequiredExtension('http', 'package2'),
+            Requirement::forRequiredExtension('openssl', 'package3'),
+            Requirement::forRequiredExtension('phar', 'package1'),
+            Requirement::forProvidedExtension('http', 'package3'),
+        ]);
 
-        $actual = $builder->build();
-
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);
+        $this->assertAllRequirementsEquals($expectedAllRequirements);
     }
 
     public function test_it_does_not_remove_extension_conflicts_if_they_are_provided(): void
     {
-        $builder = new RequirementsBuilder();
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package1',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package2',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('phar'),
             'package1',
         );
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('openssl'),
             'package3',
         );
-        $builder->addProvidedExtension(
+        $this->builder->addProvidedExtension(
             new Extension('http'),
             'package3',
         );
 
-        $expected = new Requirements([
+        $expectedBuiltRequirements = new Requirements([
             Requirement::forRequiredExtension('openssl', 'package3'),
             Requirement::forRequiredExtension('phar', 'package1'),
         ]);
+        $expectedAllRequirements = new Requirements([
+            Requirement::forRequiredExtension('http', 'package1'),
+            Requirement::forRequiredExtension('http', 'package2'),
+            Requirement::forRequiredExtension('openssl', 'package3'),
+            Requirement::forRequiredExtension('phar', 'package1'),
+            Requirement::forProvidedExtension('http', 'package3'),
+        ]);
 
-        $actual = $builder->build();
-
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);
+        $this->assertAllRequirementsEquals($expectedAllRequirements);
     }
 
     public function test_it_can_have_an_extension_that_is_required_and_conflicting_at_the_same_time(): void
     {
         // This scenario does not really make sense but ensuring this does not happen is Composer's job not Box.
-        $builder = new RequirementsBuilder();
-        $builder->addRequiredExtension(
+        $this->builder->addRequiredExtension(
             new Extension('http'),
             'package1',
         );
-        $builder->addConflictingExtension(
+        $this->builder->addConflictingExtension(
             new Extension('http'),
             'package2',
         );
@@ -233,9 +244,11 @@ final class RequirementsBuilderTest extends TestCase
             Requirement::forConflictingExtension('http', 'package2'),
         ]);
 
-        $actual = $builder->build();
+        $builtRequirements = $this->builder->build();
+        $allRequirements = $this->builder->all();
 
-        self::assertEquals($expected, $actual);
+        self::assertEquals($expected, $builtRequirements);
+        self::assertEquals($expected, $allRequirements);
     }
 
     // TODO: this could be solved
@@ -243,16 +256,15 @@ final class RequirementsBuilderTest extends TestCase
     {
         $predefinedRequirement = Requirement::forRequiredExtension('http', null);
 
-        $builder = new RequirementsBuilder();
-        $builder->addRequirement($predefinedRequirement);
-        $builder->addProvidedExtension(
+        $this->builder->addRequirement($predefinedRequirement);
+        $this->builder->addProvidedExtension(
             new Extension('http'),
             'package3',
         );
 
         $expected = new Requirements([$predefinedRequirement]);
 
-        $actual = $builder->build();
+        $actual = $this->builder->build();
 
         self::assertEquals($expected, $actual);
     }
@@ -262,25 +274,23 @@ final class RequirementsBuilderTest extends TestCase
         array $predefinedRequirements,
         array $requiredExtensionSourcePairs,
         array $conflictingExtensionSourcePairs,
-        Requirements $expected,
+        Requirements $expectedBuiltRequirements,
+        Requirements $expectedAllRequirements,
     ): void {
-        $builder = new RequirementsBuilder();
-
         foreach ($predefinedRequirements as $predefinedRequirement) {
-            $builder->addRequirement($predefinedRequirement);
+            $this->builder->addRequirement($predefinedRequirement);
         }
 
         foreach ($requiredExtensionSourcePairs as [$requiredExtension, $source]) {
-            $builder->addRequiredExtension($requiredExtension, $source);
+            $this->builder->addRequiredExtension($requiredExtension, $source);
         }
 
         foreach ($conflictingExtensionSourcePairs as [$conflictingExtension, $source]) {
-            $builder->addConflictingExtension($conflictingExtension, $source);
+            $this->builder->addConflictingExtension($conflictingExtension, $source);
         }
 
-        $actual = $builder->build();
-
-        self::assertEquals($expected, $actual);
+        $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);
+        $this->assertAllRequirementsEquals($expectedAllRequirements);
     }
 
     public static function requirementsProvider(): iterable
@@ -302,6 +312,11 @@ final class RequirementsBuilderTest extends TestCase
                 $predefinedRequirementNull,
                 $predefinedRequirementA,
             ]),
+            new Requirements([
+                $predefinedRequirementZ,
+                $predefinedRequirementNull,
+                $predefinedRequirementA,
+            ]),
         ];
 
         yield 'required extension sources' => [
@@ -317,6 +332,11 @@ final class RequirementsBuilderTest extends TestCase
                 Requirement::forRequiredExtension('noop', 'A'),
                 Requirement::forRequiredExtension('noop', 'Z'),
             ]),
+            new Requirements([
+                Requirement::forRequiredExtension('noop', null),
+                Requirement::forRequiredExtension('noop', 'A'),
+                Requirement::forRequiredExtension('noop', 'Z'),
+            ]),
         ];
 
         yield 'required extensions' => [
@@ -326,6 +346,10 @@ final class RequirementsBuilderTest extends TestCase
                 [new Extension('a-ext'), null],
             ],
             [],
+            new Requirements([
+                Requirement::forRequiredExtension('a-ext', null),
+                Requirement::forRequiredExtension('z-ext', null),
+            ]),
             new Requirements([
                 Requirement::forRequiredExtension('a-ext', null),
                 Requirement::forRequiredExtension('z-ext', null),
@@ -345,6 +369,11 @@ final class RequirementsBuilderTest extends TestCase
                 Requirement::forConflictingExtension('noop', 'A'),
                 Requirement::forConflictingExtension('noop', 'Z'),
             ]),
+            new Requirements([
+                Requirement::forConflictingExtension('noop', null),
+                Requirement::forConflictingExtension('noop', 'A'),
+                Requirement::forConflictingExtension('noop', 'Z'),
+            ]),
         ];
 
         yield 'conflicting extensions' => [
@@ -358,6 +387,24 @@ final class RequirementsBuilderTest extends TestCase
                 Requirement::forConflictingExtension('a-ext', null),
                 Requirement::forConflictingExtension('z-ext', null),
             ]),
+            new Requirements([
+                Requirement::forConflictingExtension('a-ext', null),
+                Requirement::forConflictingExtension('z-ext', null),
+            ]),
         ];
+    }
+
+    private function assertBuiltRequirementsEquals(Requirements $expected): void
+    {
+        $actual = $this->builder->build();
+
+        self::assertEquals($expected, $actual);
+    }
+
+    private function assertAllRequirementsEquals(Requirements $expected): void
+    {
+        $actual = $this->builder->all();
+
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/RequirementChecker/RequirementsBuilderTest.php
+++ b/tests/RequirementChecker/RequirementsBuilderTest.php
@@ -274,6 +274,7 @@ final class RequirementsBuilderTest extends TestCase
         array $predefinedRequirements,
         array $requiredExtensionSourcePairs,
         array $conflictingExtensionSourcePairs,
+        array $providedExtensionSourcePairs,
         Requirements $expectedBuiltRequirements,
         Requirements $expectedAllRequirements,
     ): void {
@@ -287,6 +288,10 @@ final class RequirementsBuilderTest extends TestCase
 
         foreach ($conflictingExtensionSourcePairs as [$conflictingExtension, $source]) {
             $this->builder->addConflictingExtension($conflictingExtension, $source);
+        }
+
+        foreach ($providedExtensionSourcePairs as [$conflictingExtension, $source]) {
+            $this->builder->addProvidedExtension($conflictingExtension, $source);
         }
 
         $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);
@@ -305,6 +310,7 @@ final class RequirementsBuilderTest extends TestCase
                 $predefinedRequirementNull,
                 $predefinedRequirementA,
             ],
+            [],
             [],
             [],
             new Requirements([
@@ -327,6 +333,7 @@ final class RequirementsBuilderTest extends TestCase
                 [new Extension('noop'), 'A'],
             ],
             [],
+            [],
             new Requirements([
                 Requirement::forRequiredExtension('noop', null),
                 Requirement::forRequiredExtension('noop', 'A'),
@@ -346,6 +353,7 @@ final class RequirementsBuilderTest extends TestCase
                 [new Extension('a-ext'), null],
             ],
             [],
+            [],
             new Requirements([
                 Requirement::forRequiredExtension('a-ext', null),
                 Requirement::forRequiredExtension('z-ext', null),
@@ -364,6 +372,7 @@ final class RequirementsBuilderTest extends TestCase
                 [new Extension('noop'), null],
                 [new Extension('noop'), 'A'],
             ],
+            [],
             new Requirements([
                 Requirement::forConflictingExtension('noop', null),
                 Requirement::forConflictingExtension('noop', 'A'),
@@ -383,6 +392,7 @@ final class RequirementsBuilderTest extends TestCase
                 [new Extension('z-ext'), null],
                 [new Extension('a-ext'), null],
             ],
+            [],
             new Requirements([
                 Requirement::forConflictingExtension('a-ext', null),
                 Requirement::forConflictingExtension('z-ext', null),
@@ -390,6 +400,38 @@ final class RequirementsBuilderTest extends TestCase
             new Requirements([
                 Requirement::forConflictingExtension('a-ext', null),
                 Requirement::forConflictingExtension('z-ext', null),
+            ]),
+        ];
+
+        yield 'provided extension sources' => [
+            [],
+            [],
+            [],
+            [
+                [new Extension('noop'), 'Z'],
+                [new Extension('noop'), null],
+                [new Extension('noop'), 'A'],
+            ],
+            new Requirements([]),
+            new Requirements([
+                Requirement::forProvidedExtension('noop', null),
+                Requirement::forProvidedExtension('noop', 'A'),
+                Requirement::forProvidedExtension('noop', 'Z'),
+            ]),
+        ];
+
+        yield 'provided extensions' => [
+            [],
+            [],
+            [],
+            [
+                [new Extension('z-ext'), null],
+                [new Extension('a-ext'), null],
+            ],
+            new Requirements([]),
+            new Requirements([
+                Requirement::forProvidedExtension('a-ext', null),
+                Requirement::forProvidedExtension('z-ext', null),
             ]),
         ];
     }


### PR DESCRIPTION
This is a preparatory step for #1273. The goal is to be able to provide _all_ the requirements. The idea being that one may be interested in seeing this full list for debugging purpose, rather than the strict final one where the provided extensions removed the required extensions from the calculated requirements.