### PR TITLE
feat: Group by source the required and provided extensions

### DIFF
--- a/src/RequirementChecker/RequirementsBuilder.php
+++ b/src/RequirementChecker/RequirementsBuilder.php
@@ -138,7 +138,7 @@ final class RequirementsBuilder
                 usort(
                     $sources,
                     static fn (array $sourceTypePairA, array $sourceTypePairB) => strcmp(
-                        (string) $sourceTypePairA[0],
+                        $sourceTypePairA[0],
                         (string) $sourceTypePairB[0],
                     ),
                 );

--- a/tests/RequirementChecker/RequirementsBuilderTest.php
+++ b/tests/RequirementChecker/RequirementsBuilderTest.php
@@ -69,6 +69,10 @@ final class RequirementsBuilderTest extends TestCase
             'package2',
         );
         $this->builder->addRequiredExtension(
+            new Extension('http'),
+            null,
+        );
+        $this->builder->addRequiredExtension(
             new Extension('phar'),
             'package1',
         );
@@ -83,6 +87,7 @@ final class RequirementsBuilderTest extends TestCase
         );
 
         $expected = new Requirements([
+            Requirement::forRequiredExtension('http', null),
             Requirement::forRequiredExtension('http', 'package1'),
             Requirement::forRequiredExtension('http', 'package2'),
             Requirement::forRequiredExtension('openssl', 'package3'),

--- a/tests/RequirementChecker/RequirementsBuilderTest.php
+++ b/tests/RequirementChecker/RequirementsBuilderTest.php
@@ -179,9 +179,9 @@ final class RequirementsBuilderTest extends TestCase
         $expectedAllRequirements = new Requirements([
             Requirement::forRequiredExtension('http', 'package1'),
             Requirement::forRequiredExtension('http', 'package2'),
+            Requirement::forProvidedExtension('http', 'package3'),
             Requirement::forRequiredExtension('openssl', 'package3'),
             Requirement::forRequiredExtension('phar', 'package1'),
-            Requirement::forProvidedExtension('http', 'package3'),
         ]);
 
         $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);
@@ -218,9 +218,9 @@ final class RequirementsBuilderTest extends TestCase
         $expectedAllRequirements = new Requirements([
             Requirement::forRequiredExtension('http', 'package1'),
             Requirement::forRequiredExtension('http', 'package2'),
+            Requirement::forProvidedExtension('http', 'package3'),
             Requirement::forRequiredExtension('openssl', 'package3'),
             Requirement::forRequiredExtension('phar', 'package1'),
-            Requirement::forProvidedExtension('http', 'package3'),
         ]);
 
         $this->assertBuiltRequirementsEquals($expectedBuiltRequirements);


### PR DESCRIPTION
Instead of first dividing by category (required or provided) and then by source, we no longer devide by category.

This allows to better inspect what the status is for a given extension with the `info:requirements` command (see !1273).