### PR TITLE
test: Fix composer path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
     "suggest": {
         "ext-openssl": "To accelerate private key generation."
     },
+    "conflicts": {
+        "symfony/console": "<6.4.17"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -63,9 +63,6 @@
     "suggest": {
         "ext-openssl": "To accelerate private key generation."
     },
-    "conflicts": {
-        "symfony/console": "<6.4.17"
-    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {

--- a/tests/Console/Command/CompileCommandTest.php
+++ b/tests/Console/Command/CompileCommandTest.php
@@ -3061,7 +3061,7 @@ class CompileCommandTest extends FileSystemTestCase
     private static function createComposerPathNormalizer(): callable
     {
         return static fn (string $output): string => preg_replace(
-            '/(\/.*?composer)/',
+            '/(\/.*?composer(?:\.phar)?)/',
             '/usr/local/bin/composer',
             $output,
         );


### PR DESCRIPTION
For some reasons (not entirely sure why tbh), we end up with `composer.phar` in the CI resulting in a different path than the one expected.