### PR TITLE
docs: Fix link redirection

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1074,6 +1074,6 @@ The short commit hash will only be used if no tag is available.
 [the signing best practices]: ./phar-signing.md#phar-signing-best-practices
 [stub-stub]: #stub-stub
 [stub]: #stub
-[symfony-finder]: https://symfony.com/doc/current//components/finder.html
+[symfony-finder]: https://symfony.com/doc/current/components/finder.html
 [zlib-extension]: https://secure.php.net/manual/en/book.zlib.php
 [#1152]: https://github.com/box-project/box/issues/1152


### PR DESCRIPTION
The link was handled by `symfony.com` thanks to their redirect but lychee did not appreciate the redirects in the CI. We should use the correct link in the first place though.