### PR TITLE
build: Bump the minimum version of marc-mabe/php-enum used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
         "symfony/polyfill-php81": "*",
         "symfony/polyfill-php82": "*"
     },
+    "conflict": {
+        "marc-mabe/php-enum": "<4.4"
+    },
     "suggest": {
         "ext-openssl": "To accelerate private key generation."
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1bd6cdb0ccfcbc3efc4567ba90260e0",
+    "content-hash": "209017f853fee50c4f9f72072e3a78c0",
     "packages": [
         {
             "name": "amphp/amp",
@@ -6437,7 +6437,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -6453,5 +6453,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`marc-mabe/php-enum` is not used by Box directly but required by `justinrainbow/json-schema` (which is a box dependency). But outdated versions trigger warnings in PHP 8.2+.